### PR TITLE
GNOM-2102

### DIFF
--- a/flex/views/experiment/NavExperimentView.mxml
+++ b/flex/views/experiment/NavExperimentView.mxml
@@ -399,7 +399,7 @@
         	browseTree.dataProvider.source = new XMLList(getProjectRequestList.lastResult);
 			browseTree.dataProvider.refresh();
         	callLater(expandAndReselectTree);    	
-        	
+        	this.experimentDetailView.detail.theTab.selectedIndex = 0;
 	    }
 			
 		private function onPromptToShowLabExperiments(event:CloseEvent):void {
@@ -675,9 +675,7 @@
 					browseView.refreshDownloadList();
 					browseView.refreshTrackList();
 					browseView.refreshVisibilityList();
-					
 					experimentDetailView.detail.refreshDownloadList();
-					
 				}
 				
 				experimentViews.selectedIndex=0;
@@ -1387,8 +1385,8 @@
 			
 			this.browseUserCombo.dropdown.dataProvider = appUsers;  
 	        this.browseUserCombo.selectedIndex = 0;
-			
-		}	    
+			//this.experimentDetailView.detail.theTab.selectedIndex = 0;
+		}
 
         private function sortAppUsers(obj1:Object, obj2:Object, fields:Array=null):int {
 			if (obj1 == null && obj2 == null) {

--- a/flex/views/experiment/NavExperimentView.mxml
+++ b/flex/views/experiment/NavExperimentView.mxml
@@ -1385,7 +1385,6 @@
 			
 			this.browseUserCombo.dropdown.dataProvider = appUsers;  
 	        this.browseUserCombo.selectedIndex = 0;
-			//this.experimentDetailView.detail.theTab.selectedIndex = 0;
 		}
 
         private function sortAppUsers(obj1:Object, obj2:Object, fields:Array=null):int {


### PR DESCRIPTION
This is due to the fact that we have some performance code that doesn't load the files tree unless the user explicitly clicks the file tab.

So to keep the performance improvement, if the files tab is currently selected when the user goes to click on a new experiment move them to the overview tab.

This will force them to click the files tab if they need to see it and load that data at that time.