### PR TITLE
Gnome 2106  jdewell The returned list of experiments differs when users select the "Link to experiment button"

### DIFF
--- a/flex/views/analysis/AnalysisDownloadView.mxml
+++ b/flex/views/analysis/AnalysisDownloadView.mxml
@@ -845,9 +845,8 @@
 				<mx:HierarchicalData source="{downloadList}"/>
 			</mx:dataProvider>						  
 			<mx:columns>
-				<mx:AdvancedDataGridColumn dataField="@displayName"  editable="false" headerText="Folder or File" width="165"/> 
-				<mx:AdvancedDataGridColumn dataField="@viewURL" headerText="" editable="false" width="20" itemRenderer="views.renderers.LinkButtonViewFile"/>
-				<mx:AdvancedDataGridColumn dataField="@fileSizeText" editable="false" headerText="Size" width="20" textAlign="right" /> 
+				<mx:AdvancedDataGridColumn dataField="@displayName"  editable="false" headerText="Folder or File" width="165" itemRenderer="views.renderers.AnalysisDownloadRenderer"/>
+				<mx:AdvancedDataGridColumn dataField="@fileSizeText" editable="false" headerText="Size" width="20" textAlign="right" />
 				<mx:AdvancedDataGridColumn dataField="@lastModifyDateDisplay" editable="false" headerText="Modified" width="20"/>
 				<mx:AdvancedDataGridColumn dataField="@URLLinkAllowed" headerText="URL" editable="false" width="15" minWidth="15" itemRenderer="views.renderers.LinkButtonURLLink"/>
 				<mx:AdvancedDataGridColumn dataField="@UCSCViewer" headerText="UCSC" editable="false" width="15" minWidth="15" itemRenderer="views.renderers.LinkButtonUCSCViewer"/>

--- a/flex/views/analysis/AnalysisDownloadView.mxml
+++ b/flex/views/analysis/AnalysisDownloadView.mxml
@@ -845,7 +845,7 @@
 				<mx:HierarchicalData source="{downloadList}"/>
 			</mx:dataProvider>						  
 			<mx:columns>
-				<mx:AdvancedDataGridColumn dataField="@displayName"  editable="false" headerText="Folder or File" width="165" itemRenderer="views.renderers.AnalysisDownloadRenderer"/>
+				<mx:AdvancedDataGridColumn dataField="@displayName"  editable="false" headerText="Folder or File" width="185" itemRenderer="views.renderers.AnalysisDownloadRenderer"/>
 				<mx:AdvancedDataGridColumn dataField="@fileSizeText" editable="false" headerText="Size" width="20" textAlign="right" />
 				<mx:AdvancedDataGridColumn dataField="@lastModifyDateDisplay" editable="false" headerText="Modified" width="20"/>
 				<mx:AdvancedDataGridColumn dataField="@URLLinkAllowed" headerText="URL" editable="false" width="15" minWidth="15" itemRenderer="views.renderers.LinkButtonURLLink"/>

--- a/flex/views/analysis/LinkToExpWindow.mxml
+++ b/flex/views/analysis/LinkToExpWindow.mxml
@@ -44,8 +44,9 @@
 			public function init():void{
 				var params:Object = new Object();
 				params.includePlateInfo = 'N';
-				params.linkToAnalysisExpsOnly = 'Y';
+				params.linkToAnalysisExpsOnly = 'N';
 				params.idLab = this.idLab;
+				params.ignoreMaxRequestLimit = 'Y';
 				getRequestList.send(params);
 				labCombo.selectedIndex = this.getSelectedLabIndex();
 			}

--- a/flex/views/renderers/AnalysisDownloadRenderer.as
+++ b/flex/views/renderers/AnalysisDownloadRenderer.as
@@ -1,0 +1,63 @@
+/**
+ * Created by u6008750 on 8/12/2016.
+ */
+package views.renderers
+{
+import flash.events.MouseEvent;
+import flash.net.URLRequest;
+import flash.net.navigateToURL;
+import mx.controls.advancedDataGridClasses.AdvancedDataGridGroupItemRenderer;
+
+
+public class AnalysisDownloadRenderer extends AdvancedDataGridGroupItemRenderer {
+
+    public function AnalysisDownloadRenderer() {
+        super();
+        this.addEventListener(MouseEvent.CLICK, clickLink);
+    }
+
+    private function clickLink(event:MouseEvent):void{
+        if (data.hasOwnProperty("@viewURL")) {
+            var url:URLRequest = new URLRequest(data.@viewURL);
+            navigateToURL(url, '_blank');
+        }
+    }
+
+    override protected function updateDisplayList(w:Number, h:Number):void
+    {
+        super.updateDisplayList(w, h);
+        if (data != null) {
+
+            if (data.hasOwnProperty("@viewURL") && data.@viewURL != "") {
+                label.text=data.@displayName;
+                this.setStyle("color", "Blue" );
+            }
+            else {
+                label.text=getDownloadName(data);
+
+                this.setStyle("color", "Black");
+            }
+            super.label.setActualSize(Math.max(unscaledWidth - super.label.x, 4), unscaledHeight);
+        }
+    }
+
+    override public function set data(value:Object):void {
+        super.data = value;
+
+    }
+
+    private function getDownloadName(item:Object):String {
+        var empty:String = item.name() == "Request" && item.hasOwnProperty("@isEmpty") && item.@isEmpty == "Y" ? " (no downloads)" : "";
+        if (item.name() == "RequestDownload") {
+            if (item.hasOwnProperty("@itemNumber") && item.@itemNumber != '') {
+                var results:String = item.hasOwnProperty("@results") && item.@results != '' ? " - " + item.@results : '';
+                return item.@itemNumber + results + empty;
+            } else {
+                return item.@results + empty;
+            }
+        } else {
+            return item.@displayName + empty;
+        }
+    }
+}
+}

--- a/src/hci/gnomex/controller/GetAnalysisDownloadList.java
+++ b/src/hci/gnomex/controller/GetAnalysisDownloadList.java
@@ -215,10 +215,6 @@ public class GetAnalysisDownloadList extends GNomExCommand implements Serializab
 
 							AnalysisFile af = (AnalysisFile) knownAnalysisFileMap.get(fd.getQualifiedFileName());
 
-							if (fd != null && fd.getDisplayName().equals(Constants.UPLOAD_STAGING_DIR)) {
-								continue;
-							}
-
 							Element fdNode = new Element("FileDescriptor");
 
 							if (af != null) {
@@ -389,7 +385,7 @@ public class GetAnalysisDownloadList extends GNomExCommand implements Serializab
 			List theFiles = (List) directoryMap.get(directoryKey);
 
 			// For each file in the directory
-			if (theFiles != null && theFiles.size() > 0) {
+			if (theFiles != null && theFiles.size() > 0 && !directoryName.equals( Constants.UPLOAD_STAGING_DIR)) {
 				for (Iterator i2 = theFiles.iterator(); i2.hasNext();) {
 					FileDescriptor fd = (FileDescriptor) i2.next();
 					fd.setQualifiedFilePath(directoryName);

--- a/src/hci/gnomex/controller/GetRequestList.java
+++ b/src/hci/gnomex/controller/GetRequestList.java
@@ -40,6 +40,7 @@ public class GetRequestList extends GNomExCommand implements Serializable {
 
   private Boolean includePlateInfo = true;
   private Boolean linkToAnalysisExpsOnly = false;
+  private Boolean ignoreMaxRequestLimit = false;
 
   private String message = "";
   private static final int DEFAULT_MAX_REQUESTS_COUNT = 100;
@@ -59,6 +60,9 @@ public class GetRequestList extends GNomExCommand implements Serializable {
 
     if (request.getParameter("linkToAnalysisExpsOnly") != null && !request.getParameter("linkToAnalysisExpsOnly").equals("")) {
       linkToAnalysisExpsOnly = request.getParameter("linkToAnalysisExpsOnly").equals("Y") ? true : false;
+    }
+    if (request.getParameter("ignoreMaxRequestLimit") != null && !request.getParameter("ignoreMaxRequestLimit").equals("")) {
+      ignoreMaxRequestLimit = request.getParameter("ignoreMaxRequestLimit").equals("Y") ? true : false;
     }
   }
 
@@ -213,12 +217,18 @@ public class GetRequestList extends GNomExCommand implements Serializable {
 
   private Integer getMaxRequests(Session sess) {
     Integer maxRequests = DEFAULT_MAX_REQUESTS_COUNT;
-    String prop = PropertyDictionaryHelper.getInstance(sess).getProperty(PropertyDictionary.EXPERIMENT_VIEW_LIMIT);
-    if (prop != null && prop.length() > 0) {
-      try {
-        maxRequests = Integer.parseInt(prop);
-      } catch (NumberFormatException e) {
+
+    if (!ignoreMaxRequestLimit) {
+      String prop = PropertyDictionaryHelper.getInstance(sess).getProperty(PropertyDictionary.EXPERIMENT_VIEW_LIMIT);
+      if (prop != null && prop.length() > 0) {
+        try {
+          maxRequests = Integer.parseInt(prop);
+        } catch (NumberFormatException e) {
+        }
       }
+    }
+    else {
+      maxRequests = 2000000;
     }
     return maxRequests;
   }


### PR DESCRIPTION
It was found that in the case where the number of linked experiments exceeded 100 only 100 would be displayed or the value in Configure->Add/Edit Dictionaries->Admin->experiment_view_limit. This explains why some experiments didn't show up in the popup.  Additionally, it was discovered that a configuration in Configure->Configure Experiment Platform->Associate With Analysis was unchecked then no Experiments would be returned. This explains why some customers complained that the window was empty. I corrected this in the case of the Linked Experiment button being pushed it would ignore the configuration setting and force it to be set. This will sync with what is shown in the edit list. 