### PR TITLE
GNOM-2113: Move library prep question bugfix

### DIFF
--- a/flex/views/experiment/ExperimentEditView.mxml
+++ b/flex/views/experiment/ExperimentEditView.mxml
@@ -1114,17 +1114,6 @@
 					this.userWarningStack.selectedChild = this.userWarningsBoxSampleSetup;
 				} else if (this.isMicroarrayState() && theTab.selectedChild == this.hybSetupView) {
 					this.userWarningStack.selectedChild = this.userWarningsBoxHybSetup
-				} else if (theTab.selectedChild == this.seqSetupView) {
-					if (this.sampleSetupView.currentState == "MDMiSeqState") {
-						seqSetupView.text1.width = 340;
-						seqSetupView.samplePoolingLabel.width = 340;
-					}else if( this.currentState == "NanoStringState") {
-						seqSetupView.isPreppedContainer.visible = false;
-						seqSetupView.isPreppedContainer.includeInLayout = false;
-						seqSetupView.prePooledSamplesHBox.visible = false;
-						seqSetupView.prePooledSamplesHBox.includeInLayout = false;
-					}
-
 				} else {
 					this.userWarningStack.selectedIndex = 0;
 				}

--- a/flex/views/experiment/TabSeqSetupView.mxml
+++ b/flex/views/experiment/TabSeqSetupView.mxml
@@ -82,7 +82,27 @@
 			if (parentDocument.getIdLab() == null) {
 				return;
 			}
-			
+
+			if (parentDocument.sampleSetupView.currentState == "MDMiSeqState") {
+				text1.width = 340;
+				samplePoolingLabel.width = 340;
+			} else {
+				text1.width = 305;
+				samplePoolingLabel.width = 305;
+			}
+			if (parentDocument.currentState == "NanoStringState") {
+				isPreppedContainer.visible = false;
+				isPreppedContainer.includeInLayout = false;
+				prePooledSamplesHBox.visible = false;
+				prePooledSamplesHBox.includeInLayout = false;
+			} else {
+				isPreppedContainer.visible = true;
+				isPreppedContainer.includeInLayout = true;
+				prePooledSamplesHBox.visible = samplesAlreadyPreppedCheckbox.selected;
+				prePooledSamplesHBox.includeInLayout = samplesAlreadyPreppedCheckbox.selected;
+			}
+			updateLabelApplicationText();
+
 			// Only initialize once.
 //			if (themeList != null && codeRequestCategoryInitted == parentDocument.getRequestCategory().@codeRequestCategory
 //				&& seqPrepByCoreInitted == localPrepByCore && idLabInitted == parentDocument.getIdLab()) {
@@ -377,13 +397,28 @@
 			loadedPriceIdLab = selectedPriceIdLab;
 			loadedPriceCodeRequestCategory = selectedPriceCodeRequestCategory;
 		}
+
+		/**
+		 * Updates the question number of the sequencing experiment type question
+		 */
+		private function updateLabelApplicationText():void {
+			if (isPreppedContainer.visible) {
+				if (seqPrepRadioGroup.selectedValue ==  null || seqPrepRadioGroup.selectedValue == 'Y') {
+					this.labelApplication.label="(2) Select a sequencing experiment type.";
+				} else {
+					this.labelApplication.label="(3) Select a sequencing experiment type.";
+				}
+			} else {
+				this.labelApplication.label="(1) Select a sequencing experiment type.";
+			}
+		}
+
 		/*	onClick of "Do you want the Core Facility to perform library preparation on the samples?"
 		 *
 		 * */
 		private function pickSeqPrepState():void {
-
+			updateLabelApplicationText();
 			if (seqPrepRadioGroup.selectedValue ==  null || seqPrepRadioGroup.selectedValue == 'Y') {
-				this.labelApplication.label="(2) Select a sequencing experiment type.";
 				this.prePooledSamplesRadioGroup.selection = null;
 				this.prePooledNumTubes.text = "";
 				if (parentDocument.isAmendState()) {
@@ -392,7 +427,6 @@
 					parentDocument.sampleSetupView.currentState = 'SolexaSetupState';
 				}
 			} else {
-				this.labelApplication.label="(3) Select a sequencing experiment type.";
 				if (parentDocument.isAmendState()) {
 					parentDocument.sampleSetupView.currentState = 'SolexaAmendPreppedState';
 				} else if (parentDocument.sampleSetupView.currentState != 'MDMiSeqState') {
@@ -448,7 +482,7 @@
 					</mx:HBox>
 
 					<mx:HBox >
-						<mx:RadioButton id="samplesAlreadyPreppedCheckbox"  value="Y" groupName="seqPrepRadioGroup" label="No, library has already been prepped "
+						<mx:RadioButton id="samplesAlreadyPreppedCheckbox"  value="N" groupName="seqPrepRadioGroup" label="No, library has already been prepped "
 										click="{pickSeqPrepState()}">
 						</mx:RadioButton>
 					</mx:HBox>


### PR DESCRIPTION
1. A new Nano String Experiment for Molecular Diagnostics will still hide the library prep question as intended, but now selecting a different type of experiment afterward will unhide the question so it can be answered.
2. The question numbering on the "Library Prep" tab now works on a Nano String Experiment where it is question #1.
3. The "No, library has already been prepped" response on the library prep question again has a value of "N" as intended.