### PR TITLE
GNOM-2136 : Move "QC CONC" and "QC RIN" columns on samples grid for HTG core

### DIFF
--- a/flex/views/experiment/ExperimentDetailView.mxml
+++ b/flex/views/experiment/ExperimentDetailView.mxml
@@ -21,713 +21,691 @@
 	
 	<mx:Script>
 		<![CDATA[
-			import hci.flex.controls.DropdownLabel;
-			import hci.flex.util.DictionaryManager;
+		import hci.flex.controls.DropdownLabel;
 
-			import mx.collections.Grouping;
-			import mx.collections.GroupingCollection;
-			import mx.collections.GroupingField;
-			import mx.collections.XMLListCollection;
-			import mx.controls.Alert;
-			import mx.core.Container;
-			import mx.events.CloseEvent;
-			import mx.events.IndexChangedEvent;
-			import mx.formatters.NumberFormatter;
-			import mx.managers.PopUpManager;
-			import mx.rpc.events.ResultEvent;
-			import mx.utils.ObjectUtil;
-			
-			import views.experiment.ExperimentEditView;
-			import views.order.NavOrderView;
-			import views.renderers.MultiselectRenderer;
-			import views.renderers.Text;
-			import views.renderers.URLRenderer;
-			import views.util.AdvancedDataGridToolTipColumn;
-			import views.util.AnnotationUtility;
-			import views.util.CollaboratorWindow;
-			import views.util.GNomExStringUtil;
-			import views.util.RequestStatusComparator;
-			
-			public var sampleGroupingCollection:GroupingCollection = null;		
-			
-			
-			[Bindable]
-			public var globalAdapterSize:int = 0;
-			[Bindable]
-			private var requestCategoryName:String;
-			[Bindable]
-			public var isClinicalResearch:String = 'N';
-			[Bindable]
-			private var experimentCategoryName:String;
-			[Bindable]
-			private var seqLibTreatments:String;
-			[Bindable]
-			private var visibilityName:String;
-			[Bindable]
-			private var institutionName:String;
-			[Bindable]
-			private var relatedDataTitle:String = "Related Data";
-			
-			[Bindable]
-			public var selectedExperiment:Object;
-			
-			[Bindable]
-			private var genomeBuild:String = "";
-			
-			[Bindable]
-			private var organismName:String = "";
+		import mx.collections.Grouping;
+		import mx.collections.GroupingCollection;
+		import mx.collections.GroupingField;
+		import mx.collections.XMLListCollection;
+		import mx.controls.Alert;
+		import mx.core.Container;
+		import mx.events.CloseEvent;
+		import mx.events.IndexChangedEvent;
+		import mx.formatters.NumberFormatter;
+		import mx.managers.PopUpManager;
+		import mx.rpc.events.ResultEvent;
+		import mx.utils.ObjectUtil;
 
-			[Bindable]
-			private var libPrepCompletedBy:String = "";
+		import views.renderers.MultiselectRenderer;
+		import views.renderers.URLRenderer;
+		import views.renderers.DropdownLabelBillingItem;
+		import views.util.AdvancedDataGridToolTipColumn;
+		import views.util.AnnotationUtility;
+		import views.util.CollaboratorWindow;
+		import views.util.GNomExStringUtil;
+		import views.util.RequestStatusComparator;
 
-			
-			[Bindable]
-			private var alignToGenomeBuild:String = "N";
-			
-			[Bindable]
-			private var concHeader:String = "Conc. ";
-			
-			public var defaultTab:Container = null;
-			
-			private var numberFormatter:NumberFormatter = new NumberFormatter();
-			private var sampleConcentrationPrecision:Number = -1;
-			
-			public function isCapSeqState():Boolean {
-				if (currentState == 'CapSeqState') {
-					return true;
-				} else {
-					return false;
+		public var sampleGroupingCollection:GroupingCollection = null;
+
+
+		[Bindable]
+		public var globalAdapterSize:int = 0;
+		[Bindable]
+		private var requestCategoryName:String;
+		[Bindable]
+		public var isClinicalResearch:String = 'N';
+		[Bindable]
+		private var experimentCategoryName:String;
+		[Bindable]
+		private var visibilityName:String;
+		[Bindable]
+		private var institutionName:String;
+		[Bindable]
+		private var relatedDataTitle:String = "Related Data";
+
+		[Bindable]
+		public var selectedExperiment:Object;
+
+		[Bindable]
+		private var genomeBuild:String = "";
+
+		[Bindable]
+		private var organismName:String = "";
+
+		[Bindable]
+		private var libPrepCompletedBy:String = "";
+
+
+		[Bindable]
+		private var alignToGenomeBuild:String = "N";
+
+		[Bindable]
+		private var concHeader:String = "Conc. ";
+
+		public var defaultTab:Container = null;
+
+		private var numberFormatter:NumberFormatter = new NumberFormatter();
+		private var sampleConcentrationPrecision:Number = -1;
+
+		public function isCapSeqState():Boolean {
+			return (currentState == 'CapSeqState');
+		}
+
+		public function isMitSeqState():Boolean {
+			return (currentState == 'MitSeqState');
+		}
+
+		public function isFragAnalState():Boolean {
+			return (currentState == 'FragAnalState');
+		}
+
+		public function isCherryPickState():Boolean {
+			return (currentState == 'CherryPickState');
+		}
+
+		public function isIScanState():Boolean {
+			return (currentState == 'IScanState');
+		}
+
+		public function isSequenomState():Boolean {
+			return (currentState == 'SequenomState');
+		}
+
+		public function isClinicalSequenomState():Boolean {
+			return (currentState == 'ClinicalSeqState');
+		}
+
+		public function isIsolationState():Boolean {
+			return (currentState == 'IsolationState');
+		}
+
+		public function isIonTorrentState():Boolean {
+			return (currentState == 'IonTorrentState');
+		}
+
+		public function isGenericState():Boolean {
+			return (currentState == 'GenericState');
+		}
+
+		public function isNanoStringState():Boolean {
+			return (currentState == 'NanoStringState');
+		}
+
+		public function checkSecurity():void {
+
+			if (parentApplication.isGuestMode()) {
+				this.showCy3LabelingFieldsCheckBox.visible = false;
+				this.showCy5LabelingFieldsCheckBox.visible = false;
+				this.showExtFieldsCheckBox.visible = false;
+				this.showHybFieldsCheckBox.visible = false;
+
+
+				if (parentDocument != null && parentDocument is ExperimentDetailPanel) {
+					parentDocument.requestFormButton.visible = false;
+					parentDocument.requestFormButton.includeInLayout = false;
 				}
 			}
-			
-			public function isMitSeqState():Boolean {
-				if (currentState == 'MitSeqState') {
-					return true;
-				} else {
-					return false;
+		}
+
+		public function setupForm(selectedExperiment:Object):void {
+			this.selectedExperiment = selectedExperiment;
+			sampleConcentrationPrecision = -1;
+			if (this.selectedExperiment != null && this.selectedExperiment.hasOwnProperty("@idCoreFacility")) {
+				var concentrationPrecision:Number = Number(parentApplication.getCoreFacilityProperty(this.selectedExperiment.@idCoreFacility, parentApplication.PROPERTY_SAMPLE_CONCENTRATION_PRECISION));
+				if (!isNaN(concentrationPrecision)) {
+					sampleConcentrationPrecision = concentrationPrecision;
 				}
 			}
-			
-			public function isFragAnalState():Boolean {
-				if (currentState == 'FragAnalState') {
-					return true;
-				} else {
-					return false;
+
+			parentDocument.parentDocument.experimentEditView.instantiateTabs(this.selectedExperiment.@codeRequestCategory, true, false);
+
+			genomeBuild = "";
+			this.alignToGenomeBuild = 'N';
+			organismName = "";
+			concHeader = "Conc. ";
+			var organismDict:Dictionary = new Dictionary();
+			var genomeBuildDict:Dictionary = new Dictionary();
+			for each(var seqLane:XML in selectedExperiment.sequenceLanes.SequenceLane) {
+				if (seqLane.@idGenomeBuildAlignTo != '') {
+					genomeBuildDict[String(seqLane.@idGenomeBuildAlignTo)] = parentApplication.dictionaryManager.getEntryDisplay('hci.gnomex.model.GenomeBuildLite', seqLane.@idGenomeBuildAlignTo);
+				}
+				if (seqLane.@idOrganism != '') {
+					organismDict[String(seqLane.@idOrganism)] = parentApplication.dictionaryManager.getEntryDisplay('hci.gnomex.model.OrganismLite', seqLane.@idOrganism);
 				}
 			}
-			
-			public function isCherryPickState():Boolean {
-				if (currentState == 'CherryPickState') {
-					return true;
-				} else {
-					return false;
+
+			for each(var v1:String in organismDict) {
+				organismName += v1 + ", ";
+			}
+
+			for each(var v2:String in genomeBuildDict) {
+				genomeBuild += v2 + " --- ";
+			}
+
+			genomeBuild = genomeBuild.substring(0, genomeBuild.lastIndexOf(" --- "));
+			organismName = organismName.substring(0, organismName.lastIndexOf(","));
+
+			if (genomeBuild.length > 0) {
+				this.alignToGenomeBuild = 'Y';
+			}
+
+			if (selectedExperiment.@captureLibDesignId != "" || selectedExperiment.@captureLibDesignId != "") {
+				libDesignAndInsertBox.visible = true;
+				libDesignAndInsertBox.includeInLayout = true;
+				designAndInsertLabel.text = "Custom Design Id";
+				designAndInsertText.text = selectedExperiment.@captureLibDesignId;
+			}
+			else if (libDesignAndInsertBox != null) {
+				libDesignAndInsertBox.visible = false;
+				libDesignAndInsertBox.includeInLayout = false;
+			}
+			if (relatedAnalysis.length == 0 && relatedTopics.length == 0) {
+				if (theTab.contains(this.relatedEntriesTab)) {
+					theTab.removeChild(relatedEntriesTab);
+				}
+			} else {
+				if (!theTab.contains(this.relatedEntriesTab)) {
+					theTab.addChild(relatedEntriesTab);
+				}
+
+			}
+
+			if (selectedExperiment.@canRead == 'Y' && this.billingItems.length > 0) {
+				if (!theTab.contains(this.billingTab)) {
+					theTab.addChild(billingTab);
+				}
+			} else {
+				if (theTab.contains(this.billingTab)) {
+					theTab.removeChild(billingTab);
 				}
 			}
-			
-			public function isIScanState():Boolean {
-				if (currentState == 'IScanState') {
-					return true;
-				} else {
-					return false;
-				}
-			}
-			
-			public function isSequenomState():Boolean {
-				if (currentState == 'SequenomState') {
-					return true;
-				} else {
-					return false;
-				}
-			}
-			
-			public function isClinicalSequenomState():Boolean {
-				if (currentState == 'ClinicalSeqState') {
-					return true;
-				} else {
-					return false;
-				}
-			}
-			
-			public function isIsolationState():Boolean {
-				if (currentState == 'IsolationState') {
-					return true;
-				} else {
-					return false;
-				}
-			}
-			
-			public function isIonTorrentState():Boolean {
-				if (currentState == 'IonTorrentState') {
-					return true;
-				} else {
-					return false;
-				}
-			}
-			
-			public function isGenericState():Boolean {
-				if (currentState == 'GenericState') {
-					return true;
-				} else {
-					return false;
-				}
-			}
-			
-			public function isNanoStringState():Boolean {
-				if (currentState == 'NanoStringState') {
-					return true;
-				} else {
-					return false;
-				}
-			}
-			
-			public function checkSecurity():void {
-				
-				if (parentApplication.isGuestMode()) {
-					this.showCy3LabelingFieldsCheckBox.visible = false;
-					this.showCy5LabelingFieldsCheckBox.visible = false;
-					this.showExtFieldsCheckBox.visible = false;
-					this.showHybFieldsCheckBox.visible = false;
-					
-					
-					if (parentDocument != null && parentDocument is ExperimentDetailPanel) {
-						parentDocument.requestFormButton.visible = false;	
-						parentDocument.requestFormButton.includeInLayout = false;
-					}
-				}
-			}
-			
-			public function setupForm(selectedExperiment:Object):void {
-				this.selectedExperiment = selectedExperiment;
-				sampleConcentrationPrecision = -1;
-				if (this.selectedExperiment != null && this.selectedExperiment.hasOwnProperty("@idCoreFacility")) {
-					var concentrationPrecision:Number = new Number(parentApplication.getCoreFacilityProperty(this.selectedExperiment.@idCoreFacility, parentApplication.PROPERTY_SAMPLE_CONCENTRATION_PRECISION));
-					if (!isNaN(concentrationPrecision)) {
-						sampleConcentrationPrecision = concentrationPrecision;
-					}
-				}
-				
-				parentDocument.parentDocument.experimentEditView.instantiateTabs(this.selectedExperiment.@codeRequestCategory, true, false);
-				
-				genomeBuild = "";
-				this.alignToGenomeBuild = 'N';
-				organismName = "";
-				concHeader = "Conc. ";
-				var organismDict:Dictionary = new Dictionary();
-				var genomeBuildDict:Dictionary = new Dictionary();
-				for each(var seqLane:XML in selectedExperiment.sequenceLanes.SequenceLane){
-					if(seqLane.@idGenomeBuildAlignTo != ''){
-						genomeBuildDict[String(seqLane.@idGenomeBuildAlignTo)] = parentApplication.dictionaryManager.getEntryDisplay('hci.gnomex.model.GenomeBuildLite', seqLane.@idGenomeBuildAlignTo);
-					}
-					if(seqLane.@idOrganism != ''){
-						organismDict[String(seqLane.@idOrganism)] = parentApplication.dictionaryManager.getEntryDisplay('hci.gnomex.model.OrganismLite', seqLane.@idOrganism);
-					}
-				}
-				
-				for each(var value:String in organismDict){
-					organismName += value + ", ";
-				}
-				
-				for each(var v2:String in genomeBuildDict){
-					genomeBuild += v2 + " --- ";
-				}
-				
-				genomeBuild = genomeBuild.substring(0, genomeBuild.lastIndexOf(" --- "));
-				organismName = organismName.substring(0, organismName.lastIndexOf(","));
-				
-				if(genomeBuild.length > 0){
-					this.alignToGenomeBuild = 'Y';
-				}
-								
-				var requestApplication:Object = parentApplication.dictionaryManager.getEntry('hci.gnomex.model.Application', selectedExperiment.@codeApplication);
-				if(selectedExperiment.@captureLibDesignId != "" || selectedExperiment.@captureLibDesignId != ""){
-					libDesignAndInsertBox.visible = true;
-					libDesignAndInsertBox.includeInLayout = true;
-					designAndInsertLabel.text = "Custom Design Id";
-					designAndInsertText.text = selectedExperiment.@captureLibDesignId;
-				}
-				else if ( libDesignAndInsertBox != null ) {
-					libDesignAndInsertBox.visible = false;
-					libDesignAndInsertBox.includeInLayout = false;
-				}
-				if (relatedAnalysis.length == 0 && relatedTopics.length == 0) {
-					if (theTab.contains(this.relatedEntriesTab)) {
-						theTab.removeChild(relatedEntriesTab);
-					}
-				} else {
-					if (!theTab.contains(this.relatedEntriesTab)) {
-						theTab.addChild(relatedEntriesTab);
-					}
-					
-				}
-				
-				if (selectedExperiment.@canRead == 'Y' && this.billingItems.length > 0) {
-					if (!theTab.contains(this.billingTab)) {
-						theTab.addChild(billingTab);
-					}
-				} else {
-					if (theTab.contains(this.billingTab)) {
-						theTab.removeChild(billingTab);
-					}
-				}
 				//		if (this.protocolsBox.visible) {
 				//			if (!this.headerBox.contains(this.protocolsBox)) {
 				//				this.headerBox.addChild(this.protocolsBox);
-				//			} 
+				//			}
 				//		} else {
 				//			if (this.headerBox.contains(this.protocolsBox)) {
 				//				this.headerBox.removeChild(this.protocolsBox);
-				//			} 
+				//			}
 				//		}
-				if (selectedExperiment.@projectDescription == ''){
-					this.projectDescVBox.visible = false;
-					this.projectDescVBox.includeInLayout = false;
-				} else {
-					this.projectDescVBox.visible = true;
-					this.projectDescVBox.includeInLayout = true;
-				}
-				
-				var requestCategory:Object = parentApplication.dictionaryManager.getEntry('hci.gnomex.model.RequestCategory',this.selectedExperiment.@codeRequestCategory);
-				this.currentState = '';	
-				if (this.selectedExperiment.@codeRequestCategory == "QC") {
-					if(this.selectedExperiment.@isExternal != 'Y'){
-						currentState = 'QCState';
-					}
-					else{
-						currentState = 'ExternalQCState';
-					}
-					
-				} else if (this.selectedExperiment.@isExternal != 'Y' && requestCategory.@isIlluminaType == 'Y') {
-					currentState = 'SolexaState';
-				} else if (requestCategory.@type == 'MICROARRAY') {
-					if (this.selectedExperiment.@isExternal != 'Y') {
-						currentState = 'MicroarrayState';
-						
-						
-						showCy3LabelingFieldsCheckBox.selected = false;
-						showCy5LabelingFieldsCheckBox.selected = false;
-						showHybFieldsCheckBox.selected = false;
-						showExtFieldsCheckBox.selected = false;
-						
-					} else {
-						currentState = 'ExternalMicroarrayState';
-					}
-					
-				} else if (requestCategory.@isIlluminaType == 'Y' && this.selectedExperiment.@isExternal == 'Y') {
-					currentState = 'ExternalSeqState';
-					if(headerBox != null) {
-						headerBox.visible = false;
-					}
-					
-				} else if (requestCategory.@type == 'CAPSEQ') {
-					currentState = 'CapSeqState';
-					this.chromoTab.idRequest = this.selectedExperiment.@idRequest;
-					this.chromoTab.getList();
-					for each(var doff:Object in parentApplication.dictionaryManager.xml.Dictionary.(@className == 'hci.gnomex.model.SampleDropOffLocation').DictionaryEntry) {
-						if (doff.@value == this.selectedExperiment.@idSampleDropOffLocation) {
-							this.sampleDropOffLocationText.text = doff.@display;
-						}
-					}
-				} else if (requestCategory.@type == 'MITSEQ') {
-					currentState = 'MitSeqState';
-				} else if (requestCategory.@type == 'FRAGANAL') {
-					currentState = 'FragAnalState';
-				} else if (requestCategory.@type == 'CHERRYPICK') {
-					currentState = 'CherryPickState';
-				}  else if (requestCategory.@type == 'ISCAN') {
-					this.currentState = "IScanState";
-					if ( parentDocument.parentDocument.experimentEditView.sampleSetupView != null ) {
-						parentDocument.parentDocument.experimentEditView.sampleSetupView.currentState = 'IScanState';
-						parentDocument.parentDocument.experimentEditView.sampleSetupView.updateIScanPlateList(this.selectedExperiment.iScanPlateList.Plate);
-					}					
-					parentDocument.parentDocument.experimentEditView.samplesView.currentState = 'IScanState';	
-					if ( parentDocument.parentDocument.experimentEditView.annotationView != null ) {
-						parentDocument.parentDocument.experimentEditView.annotationView.checkSecurity();
-					}
-				} else if (requestCategory.@type == 'SEQUENOM') {
-					this.currentState = "SequenomState";
-					if ( parentDocument.parentDocument.experimentEditView.sampleSetupView != null ) {
-						parentDocument.parentDocument.experimentEditView.sampleSetupView.currentState = 'SequenomState';
-					}
-					if ( this.bisulfideConversionBox != null ) {
-						this.bisulfideConversionBox.visible=requestCategory!=null && requestCategory.@codeRequestCategory=='SEQEPI';
-						this.bisulfideConversionBox.includeInLayout=requestCategory!=null && requestCategory.@codeRequestCategory=='SEQEPI';
-					}
-				} else if (requestCategory.@type == 'CLINSEQ') {
-					this.currentState = "ClinicalSeqState";
-					if ( parentDocument.parentDocument.experimentEditView.sampleSetupView != null ) {
-						parentDocument.parentDocument.experimentEditView.sampleSetupView.currentState = 'ClinicalSequenomState';	
-					}
-					parentDocument.parentDocument.experimentEditView.samplesView.currentState = 'ClinicalSequenomState';	
-				} else if (requestCategory.@type == 'ISOLATION') {
-					this.currentState = "IsolationState";
-					if ( parentDocument.parentDocument.experimentEditView.sampleSetupView != null ) {
-						parentDocument.parentDocument.experimentEditView.sampleSetupView.currentState = 'IsolationState';	
-					}	
-				}  else if ((this.selectedExperiment.@codeRequestCategory.toString()).substr( 0, 6 ) == 'IONTOR') {
-					this.currentState = "IonTorrentState";
-					if ( parentDocument.parentDocument.experimentEditView.sampleSetupView != null ) {
-						parentDocument.parentDocument.experimentEditView.sampleSetupView.currentState = 'GenericState';	
-					}	
-				} else if (requestCategory.@type == 'NANOSTRING') {
-					this.currentState = "NanoStringState";
-					if ( parentDocument.parentDocument.experimentEditView.sampleSetupView != null ) {
-						parentDocument.parentDocument.experimentEditView.sampleSetupView.currentState = 'NanoStringState';	
-					}	
-				} else if (requestCategory.@type == 'GENERIC') {
-					this.currentState = "GenericState";
-					if ( parentDocument.parentDocument.experimentEditView.sampleSetupView != null ) {
-						parentDocument.parentDocument.experimentEditView.sampleSetupView.currentState = 'GenericState';	
-					}	
-				}
-				
-				if (parentDocument != null && parentDocument is ExperimentDetailPanel) {
-					if (this.selectedExperiment.analysisExperimentItems.hasOwnProperty("AnalysisExperimentItem")) {
-						analysisButton.enabled = true;
-					} else {
-						analysisButton.enabled = false;
-					} 
-				}
-				
-				if(this.selectedExperiment.@isExternal == 'Y') {
-					if(lanesConfirmContainer != null && theTab.contains(lanesConfirmContainer)) {
-						//theTab.setChildIndex(lanesConfirmContainer, 2);
-						//lanesConfirmContainer.enabled = false;
-						/*
-						var index:int = theTab.getChildIndex(lanesConfirmContainer);
-						if (index > 0) {
-						var tabButton:Button = theTab.getTabAt(index);
-						if(tabButton != null) {
-						lanesConfirmContainer.tabIndex = theTab.numChildren+1;
-						//tabButton.visible = false;
-						}						
-						}
-						*/
-						
-					}
-				}
-				
-				if (this.linkToTopicBar != null) {
-					this.linkToTopicBar.refreshForDisplay();
-				}
-				
-				getRequestCategoryVariables();
-				getExperimentCategoryName();
-				getSeqLibTreatments();
-				getVisibilityName();
-				getInstitutionName();
-				callLater(showHideColumns);
-				this.addNonStandardSampleColumns();
+			if (selectedExperiment.@projectDescription == '') {
+				this.projectDescVBox.visible = false;
+				this.projectDescVBox.includeInLayout = false;
+			} else {
+				this.projectDescVBox.visible = true;
+				this.projectDescVBox.includeInLayout = true;
+			}
 
-				if (theTab.selectedChild == this.filesView) {
-					downloadExpandedFilesButtonView.visible = true;
-					downloadExpandedFilesButtonView.includeInLayout = true;
-				} else {
-					downloadExpandedFilesButtonView.visible = false;
-					downloadExpandedFilesButtonView.includeInLayout = false;
+			var requestCategory:Object = parentApplication.dictionaryManager.getEntry('hci.gnomex.model.RequestCategory', this.selectedExperiment.@codeRequestCategory);
+			this.currentState = '';
+			if (this.selectedExperiment.@codeRequestCategory == "QC") {
+				if (this.selectedExperiment.@isExternal != 'Y') {
+					currentState = 'QCState';
 				}
-				
+				else {
+					currentState = 'ExternalQCState';
+				}
+
+			} else if (this.selectedExperiment.@isExternal != 'Y' && requestCategory.@isIlluminaType == 'Y') {
+				currentState = 'SolexaState';
+			} else if (requestCategory.@type == 'MICROARRAY') {
+				if (this.selectedExperiment.@isExternal != 'Y') {
+					currentState = 'MicroarrayState';
+
+
+					showCy3LabelingFieldsCheckBox.selected = false;
+					showCy5LabelingFieldsCheckBox.selected = false;
+					showHybFieldsCheckBox.selected = false;
+					showExtFieldsCheckBox.selected = false;
+
+				} else {
+					currentState = 'ExternalMicroarrayState';
+				}
+
+			} else if (requestCategory.@isIlluminaType == 'Y' && this.selectedExperiment.@isExternal == 'Y') {
+				currentState = 'ExternalSeqState';
+				if (headerBox != null) {
+					headerBox.visible = false;
+				}
+
+			} else if (requestCategory.@type == 'CAPSEQ') {
+				currentState = 'CapSeqState';
+				this.chromoTab.idRequest = this.selectedExperiment.@idRequest;
+				this.chromoTab.getList();
+				for each(var doff:Object in parentApplication.dictionaryManager.xml.Dictionary.(@className == 'hci.gnomex.model.SampleDropOffLocation').DictionaryEntry) {
+					if (doff.@value == this.selectedExperiment.@idSampleDropOffLocation) {
+						this.sampleDropOffLocationText.text = doff.@display;
+					}
+				}
+			} else if (requestCategory.@type == 'MITSEQ') {
+				currentState = 'MitSeqState';
+			} else if (requestCategory.@type == 'FRAGANAL') {
+				currentState = 'FragAnalState';
+			} else if (requestCategory.@type == 'CHERRYPICK') {
+				currentState = 'CherryPickState';
+			} else if (requestCategory.@type == 'ISCAN') {
+				this.currentState = "IScanState";
+				if (parentDocument.parentDocument.experimentEditView.sampleSetupView != null) {
+					parentDocument.parentDocument.experimentEditView.sampleSetupView.currentState = 'IScanState';
+					parentDocument.parentDocument.experimentEditView.sampleSetupView.updateIScanPlateList(this.selectedExperiment.iScanPlateList.Plate);
+				}
+				parentDocument.parentDocument.experimentEditView.samplesView.currentState = 'IScanState';
+				if (parentDocument.parentDocument.experimentEditView.annotationView != null) {
+					parentDocument.parentDocument.experimentEditView.annotationView.checkSecurity();
+				}
+			} else if (requestCategory.@type == 'SEQUENOM') {
+				this.currentState = "SequenomState";
+				if (parentDocument.parentDocument.experimentEditView.sampleSetupView != null) {
+					parentDocument.parentDocument.experimentEditView.sampleSetupView.currentState = 'SequenomState';
+				}
+				if (this.bisulfideConversionBox != null) {
+					this.bisulfideConversionBox.visible = requestCategory != null && requestCategory.@codeRequestCategory == 'SEQEPI';
+					this.bisulfideConversionBox.includeInLayout = requestCategory != null && requestCategory.@codeRequestCategory == 'SEQEPI';
+				}
+			} else if (requestCategory.@type == 'CLINSEQ') {
+				this.currentState = "ClinicalSeqState";
+				if (parentDocument.parentDocument.experimentEditView.sampleSetupView != null) {
+					parentDocument.parentDocument.experimentEditView.sampleSetupView.currentState = 'ClinicalSequenomState';
+				}
+				parentDocument.parentDocument.experimentEditView.samplesView.currentState = 'ClinicalSequenomState';
+			} else if (requestCategory.@type == 'ISOLATION') {
+				this.currentState = "IsolationState";
+				if (parentDocument.parentDocument.experimentEditView.sampleSetupView != null) {
+					parentDocument.parentDocument.experimentEditView.sampleSetupView.currentState = 'IsolationState';
+				}
+			} else if ((this.selectedExperiment.@codeRequestCategory.toString()).substr(0, 6) == 'IONTOR') {
+				this.currentState = "IonTorrentState";
+				if (parentDocument.parentDocument.experimentEditView.sampleSetupView != null) {
+					parentDocument.parentDocument.experimentEditView.sampleSetupView.currentState = 'GenericState';
+				}
+			} else if (requestCategory.@type == 'NANOSTRING') {
+				this.currentState = "NanoStringState";
+				if (parentDocument.parentDocument.experimentEditView.sampleSetupView != null) {
+					parentDocument.parentDocument.experimentEditView.sampleSetupView.currentState = 'NanoStringState';
+				}
+			} else if (requestCategory.@type == 'GENERIC') {
+				this.currentState = "GenericState";
+				if (parentDocument.parentDocument.experimentEditView.sampleSetupView != null) {
+					parentDocument.parentDocument.experimentEditView.sampleSetupView.currentState = 'GenericState';
+				}
+			}
+
+			if (parentDocument != null && parentDocument is ExperimentDetailPanel) {
+				analysisButton.enabled = this.selectedExperiment.analysisExperimentItems.hasOwnProperty("AnalysisExperimentItem");
+			}
+
+			if (this.selectedExperiment.@isExternal == 'Y') {
+				if (lanesConfirmContainer != null && theTab.contains(lanesConfirmContainer)) {
+					//theTab.setChildIndex(lanesConfirmContainer, 2);
+					//lanesConfirmContainer.enabled = false;
+					/*
+					 var index:int = theTab.getChildIndex(lanesConfirmContainer);
+					 if (index > 0) {
+					 var tabButton:Button = theTab.getTabAt(index);
+					 if(tabButton != null) {
+					 lanesConfirmContainer.tabIndex = theTab.numChildren+1;
+					 //tabButton.visible = false;
+					 }
+					 }
+					 */
+
+				}
+			}
+
+			if (this.linkToTopicBar != null) {
+				this.linkToTopicBar.refreshForDisplay();
+			}
+
+			getRequestCategoryVariables();
+			getExperimentCategoryName();
+			getVisibilityName();
+			getInstitutionName();
+			callLater(showHideColumns);
+			this.addNonStandardSampleColumns();
+
+			if (theTab.selectedChild == this.filesView) {
+				downloadExpandedFilesButtonView.visible = true;
+				downloadExpandedFilesButtonView.includeInLayout = true;
+			} else {
+				downloadExpandedFilesButtonView.visible = false;
+				downloadExpandedFilesButtonView.includeInLayout = false;
+			}
+
 				//			this.theTab.selectedIndex = 0;
-				
-				// Need to refresh download list here; otherwise last selected experiment's
-				// files shown rather than current selection.
-				this.refreshDownloadList();	
-				if (relatedAnalysis.length > 0) {
-					callLater( this.relatedAnalysisTree.expandChildrenOf, [ relatedAnalysis[0], true]); 				
-				} 
-				if (relatedTopics.length > 0) {
-					callLater( this.relatedTopicsTree.expandChildrenOf, [ relatedTopics[0], true]); 
+
+			// Need to refresh download list here; otherwise last selected experiment's
+			// files shown rather than current selection.
+			this.refreshDownloadList();
+			if (relatedAnalysis.length > 0) {
+				callLater(this.relatedAnalysisTree.expandChildrenOf, [relatedAnalysis[0], true]);
+			}
+			if (relatedTopics.length > 0) {
+				callLater(this.relatedTopicsTree.expandChildrenOf, [relatedTopics[0], true]);
+			}
+
+			// If property exists, set the adapter size; otherwise it will remain at 0.
+			var propAdapterSize:Object = parentApplication.getProperty(parentApplication.PROPERTY_BASE_INSERT_SIZE);
+			if (propAdapterSize != null && propAdapterSize != '') {
+				globalAdapterSize = parseInt(String(propAdapterSize));
+			}
+
+			this.requestProperties.refresh();
+			if (this.requestProperties.length < 1) {
+				this.theTab.getTabAt(theTab.getChildIndex(propertiesView)).visible = false;
+				this.theTab.getTabAt(theTab.getChildIndex(propertiesView)).includeInLayout = false;
+			} else {
+				this.theTab.getTabAt(theTab.getChildIndex(propertiesView)).visible = true;
+				this.theTab.getTabAt(theTab.getChildIndex(propertiesView)).includeInLayout = true;
+			}
+
+			if (shouldShowMMBox()) {
+				this.theTab.getTabAt(theTab.getChildIndex(mmBox)).visible = true;
+				this.theTab.getTabAt(theTab.getChildIndex(mmBox)).includeInLayout = true;
+			} else {
+				this.theTab.getTabAt(theTab.getChildIndex(mmBox)).visible = false;
+				this.theTab.getTabAt(theTab.getChildIndex(mmBox)).includeInLayout = false;
+			}
+
+			if (determineToShowProductsTab(requestCategory) && selectedExperiment.hasOwnProperty("@codeRequestStatus") &&
+					selectedExperiment.@codeRequestStatus != "COMPLETE" && selectedExperiment.@codeRequestStatus != "FAILED") {
+				productsView.allowEdits(false);
+				productsView.refreshForRequestCategory(requestCategory);
+				productsView.refreshForLab(selectedExperiment.@idLab);
+				if (selectedExperiment.hasOwnProperty("@idProduct") && selectedExperiment.@idProduct != "") {
+					productsView.loadSelection(selectedExperiment.@idProduct, selectedExperiment.@idLab);
 				}
-				
-				// If property exists, set the adapter size; otherwise it will remain at 0.
-				var propAdapterSize:Object = parentApplication.getProperty(parentApplication.PROPERTY_BASE_INSERT_SIZE);			
-				if (propAdapterSize != null && propAdapterSize != '') {
-					globalAdapterSize = parseInt(String(propAdapterSize));			
+				productsView.enabled = true;
+				this.theTab.getTabAt(theTab.getChildIndex(productsView)).visible = true;
+				this.theTab.getTabAt(theTab.getChildIndex(productsView)).includeInLayout = true;
+			} else {
+				productsView.reset();
+				productsView.allowEdits(false);
+				productsView.enabled = false;
+				this.theTab.getTabAt(theTab.getChildIndex(productsView)).visible = false;
+				this.theTab.getTabAt(theTab.getChildIndex(productsView)).includeInLayout = false;
+			}
+
+			if (defaultTab == null) {
+				theTab.selectedIndex = 0;
+			} else {
+				theTab.selectedChild = defaultTab;
+				defaultTab = null;
+			}
+
+			//only keep unique appusers who have completed lib prep
+			libPrepCompletedBy = "";
+			var dict:Dictionary = new Dictionary();
+			for (var i:int = 0; i < samples.length; i++) {
+				if (samples.getItemAt(i).@idLibPrepPerformedBy != '') {
+					var id:String = samples.getItemAt(i).@idLibPrepPerformedBy;
+					dict[id] = id;
 				}
-				
-				this.requestProperties.refresh();
-				if (this.requestProperties.length < 1) {
-					this.theTab.getTabAt( theTab.getChildIndex( propertiesView ) ).visible = false;
-					this.theTab.getTabAt( theTab.getChildIndex( propertiesView ) ).includeInLayout = false;
+			}
+			for each (var value:String in dict) {
+				this.libPrepCompletedBy += parentApplication.dictionaryManager.xml.Dictionary.(@className == 'hci.gnomex.model.AppUserLite').DictionaryEntry.(@value != '' && @idAppUser == value).@display + '\n';
+			}
+
+			libPrepCompletionBox.visible = (libPrepCompletedBy.length > 0);
+
+			placeSpecialQualColumns();
+
+			// Workflow progress
+			callLater(setWorkflowStatus);
+
+		}
+
+		private var qualFieldsInitialized:Boolean = false;
+		private var qualCalcConcentrationWasBefore:String;
+		private var qualRINNumberWasBefore:String;
+
+		/**
+		 *  Move the "QC Concentration" and "QC RIN" columns before "Seq Lib Protocol" for High Throughput Genomics
+		 *  Otherwise return these columns to their original positions (tracked by qualXxxxxWasBefore fields)
+		 */
+		private function placeSpecialQualColumns():void {
+			if (!qualFieldsInitialized) {
+				qualCalcConcentrationWasBefore = getFieldAfter("@qualCalcConcentration");
+				qualRINNumberWasBefore = getFieldAfter("@qualRINNumber");
+				qualFieldsInitialized = true;
+			}
+			if (isHighThroughputGenomics()) {
+				moveColumnBefore("@qualCalcConcentration", "@idSeqLibProtocol");
+				moveColumnBefore("@qualRINNumber", "@idSeqLibProtocol");
+			} else {
+				moveColumnBefore("@qualRINNumber", qualRINNumberWasBefore);
+				moveColumnBefore("@qualCalcConcentration", qualCalcConcentrationWasBefore);
+			}
+		}
+
+		private function isHighThroughputGenomics():Boolean {
+			return (this.selectedExperiment.@idCoreFacility == parentApplication.idCoreFacilityHTG);
+		}
+
+		private const MISSING_INDEX:int = -1;
+		private const MISSING_FIELD:String = "MISSING_FIELD";
+		private const LAST_FIELD:String = "LAST_FIELD";
+
+		private function getFieldAfter(field:String):String {
+			var column:int = getColumnIndexFromField(field);
+			if (column == MISSING_INDEX) {
+				return MISSING_FIELD;
+			}
+			if (column == samplesGridConfirm.columns.length - 1) {
+				return LAST_FIELD;
+			}
+			return samplesGridConfirm.columns[column + 1].dataField;
+		}
+
+		private function moveColumnBefore(moveField:String, otherField:String):void {
+			var moveFromColumn:int = getColumnIndexFromField(moveField);
+			if (moveFromColumn == MISSING_INDEX) {
+				return;
+			}
+			var columnsCopy:Array = samplesGridConfirm.columns;
+			var column:AdvancedDataGridColumn = columnsCopy.removeAt(moveFromColumn);
+			var moveToColumn:int;
+			var otherColumn:int = getColumnIndexFromFieldInArray(columnsCopy, otherField);
+			if (otherColumn != MISSING_INDEX) {
+				moveToColumn = otherColumn;
+			} else {
+				moveToColumn = moveFromColumn;
+			}
+			columnsCopy.insertAt(moveToColumn, column);
+			samplesGridConfirm.columns = columnsCopy;
+			samplesGridConfirm.validateNow();
+		}
+
+		private function getColumnIndexFromField(field:String):int {
+			return getColumnIndexFromFieldInArray(samplesGridConfirm.columns, field);
+		}
+
+		private function getColumnIndexFromFieldInArray(cols:Array, field:String):int {
+			if (field == LAST_FIELD) {
+				return cols.length;
+			}
+			for (var i:int = 0; i < cols.length; i++) {
+				if (cols[i].dataField == field) {
+					return i;
+				}
+			}
+			return MISSING_INDEX;
+		}
+
+		private function shouldShowMMBox():Boolean {
+			if (libDesignAndInsertBox.visible) {
+				return true;
+			}
+			if (this.selectedExperiment.@codeIsolationPrepType != null && this.selectedExperiment.@codeIsolationPrepType != '') {
+				return true;
+			}
+			if (this.selectedExperiment.protocols.Protocol.length() > 0) {
+				return true;
+			}
+			return false;
+		}
+
+		private function setWorkflowStatus():void {
+			// Reset the progress bar labels
+			for each(var stepLabelElement:Object in this.stepLabel) {
+				stepLabelElement.setStyle("fontWeight", "normal");
+				stepLabelElement.setStyle("color", "black");
+			}
+
+			var x:int = 0;
+			for each(var progressInfo:Object in selectedExperiment.workflowStatus.Progress) {
+				this.workflowProgressBar[x].setProgress(progressInfo.@stepNumber, selectedExperiment.workflowStatus.@numberOfSteps);
+				// Add style to labels for any step that has a sample(s) in that status
+				this.stepLabel[parseInt(progressInfo.@stepNumber) - 1].setStyle("fontWeight", "bold");
+				this.stepLabel[parseInt(progressInfo.@stepNumber) - 1].setStyle("color", "#2C9D11");
+				x++;
+			}
+
+			workflowProgressBox.visible = (x > 0);
+			workflowProgressBox.includeInLayout = (x > 0);
+		}
+
+		public function initializeBarcoding():void {
+			var showSampleMultiplexGroup:Boolean = false;
+			var showSampleBarcode:Boolean = false;
+			var showSampleBarcodeB:Boolean = false;
+			var showSampleCustomBarcode:Boolean = false;
+			var showSampleCustomBarcodeB:Boolean = false;
+			var showPlates:Boolean = false;
+			for each (var s:Object in samples) {
+				if (s.@multiplexGroupNumber != '' && !isNanoStringState()) {
+					showSampleMultiplexGroup = true;
+				}
+				if (((isCapSeqState() || isSequenomState()) && s.hasOwnProperty("@plateName") && s.@plateName != '') || isIScanState()) {
+					showPlates = true;
+				}
+				if (s.@idOligoBarcode != '') {
+					showSampleBarcode = true;
+				}
+				if (s.@barcodeSequence != '') {
+					showSampleCustomBarcode = true;
+				}
+				if (s.@idOligoBarcodeB != '') {
+					showSampleBarcodeB = true;
+				}
+				if (s.@barcodeSequenceB != '') {
+					showSampleCustomBarcodeB = true;
+				}
+			}
+
+			if (showPlates) {
+
+				this.samplesGridConfirm.dataProvider = null;
+				sampleGroupingCollection = new GroupingCollection();
+				sampleGroupingCollection.source = this.samples;
+				var groupCapSeq:Grouping = new Grouping();
+				var gfCapSeq:GroupingField = new GroupingField();
+				gfCapSeq.name = "@plateName";
+				groupCapSeq.fields = [gfCapSeq];
+				gfCapSeq.compareFunction = plateSampleCompareFunction;
+				sampleGroupingCollection.grouping = groupCapSeq;
+				sampleGroupingCollection.refresh();
+				this.samplesGridConfirm.dataProvider = sampleGroupingCollection;
+
+				this.samplesGridConfirm.dragMoveEnabled = false;
+				this.samplesGridConfirm.dropEnabled = false;
+				this.samplesGridConfirm.dragEnabled = false;
+
+
+				this.switchFirstSampleGridColumns(this.plateNameCol, this.multiplexGroupNumberColumn);
+				this.plateNameCol.visible = true;
+				this.multiplexGroupNumberColumn.visible = false;
+
+			} else if (showSampleMultiplexGroup) {
+
+				this.samplesGridConfirm.dataProvider = null;
+				sampleGroupingCollection = new GroupingCollection();
+				sampleGroupingCollection.source = this.samples;
+				var group:Grouping = new Grouping();
+				var gf:GroupingField = new GroupingField();
+				gf.name = "@multiplexGroupNumber";
+				gf.compareFunction = sampleCompareFunction;
+				group.fields = [gf];
+				sampleGroupingCollection.grouping = group;
+				sampleGroupingCollection.refresh();
+				this.samplesGridConfirm.dataProvider = sampleGroupingCollection;
+
+				this.multiplexGroupNumberColumn.visible = true;
+				switchFirstSampleGridColumns(this.multiplexGroupNumberColumn, this.plateNameCol);
+				this.plateNameCol.visible = false;
+
+			} else {
+
+				sampleGroupingCollection = null;
+				this.samplesGridConfirm.dataProvider = this.samples;
+
+				this.multiplexGroupNumberColumn.visible = false;
+
+			}
+
+			this.barcodeCol.visible = showSampleBarcode;
+			this.customBarcodeCol.visible = showSampleCustomBarcode;
+			this.customBarcodeColB.visible = showSampleCustomBarcodeB;
+			this.barcodeColB.visible = showSampleBarcodeB;
+
+			if (currentState == "SolexaState") {
+				this.laneBarcodeCol.visible = showSampleBarcode;
+				this.laneBarcodeColB.visible = showSampleBarcode;
+				this.laneCustomBarcodeCol.visible = showSampleCustomBarcode;
+				this.laneCustomBarcodeColB.visible = showSampleCustomBarcode;
+			}
+
+			this.samplesGridConfirm.validateNow();
+		}
+
+		private function switchFirstSampleGridColumns(col1:AdvancedDataGridColumn, col2:AdvancedDataGridColumn):void {
+			var columns:Array = [];
+			columns[0] = col1;
+			columns[1] = col2;
+			for (var i:int = 2; i < this.samplesGridConfirm.columns.length; i++) {
+				columns[i] = this.samplesGridConfirm.columns[i];
+			}
+			this.samplesGridConfirm.columns = columns;
+		}
+
+		private function sampleCompareFunction(a:XML, b:XML):int {
+			var aPersistFlag:Number = 0;
+			var aPosition:Number = 0;
+			if (a.@idSample.toString().indexOf("Sample") > -1) {
+				aPosition = a.@idSample.toString().substr(6);
+				aPersistFlag = 1;
+			} else {
+				aPosition = a.@idSample;
+			}
+
+			var bPersistFlag:Number = 0;
+			var bPosition:Number = 0;
+			if (b.@idSample.toString().indexOf("Sample") > -1) {
+				bPosition = b.@idSample.toString().substr(6);
+				bPersistFlag = 1; // non-persistent samples sort after the persistent ones
+			} else {
+				bPosition = b.@idSample;
+			}
+
+			if (aPersistFlag == bPersistFlag) {
+				return ObjectUtil.numericCompare(aPosition, bPosition);
+			} else {
+				return ObjectUtil.numericCompare(aPersistFlag, bPersistFlag);
+			}
+		}
+
+		private function plateSampleCompareFunction(a:XML, b:XML):int {
+			if (a.hasOwnProperty("@plateName") && a.hasOwnProperty("@wellName") && b.hasOwnProperty("@plateName") && b.hasOwnProperty("@wellName")) {
+				var compVal:int = 0;
+				if (a.@plateName == b.@plateName) {
+					compVal = compVal = ObjectUtil.numericCompare(a.@wellName.toString().substr(1), b.@wellName.toString().substr(1));
+					if (compVal == 0) {
+						compVal = ObjectUtil.stringCompare(a.@wellName.toString(), b.@wellName.toString());
+					}
 				} else {
-					this.theTab.getTabAt( theTab.getChildIndex( propertiesView ) ).visible = true;
-					this.theTab.getTabAt( theTab.getChildIndex( propertiesView ) ).includeInLayout = true;
+					compVal = ObjectUtil.stringCompare(a.@plateName.toString(), b.@plateName.toString());
 				}
-				
-				if ( shouldShowMMBox() ) {
-					this.theTab.getTabAt( theTab.getChildIndex( mmBox ) ).visible = true;
-					this.theTab.getTabAt( theTab.getChildIndex( mmBox ) ).includeInLayout = true;
-				} else {
-					this.theTab.getTabAt( theTab.getChildIndex( mmBox ) ).visible = false;
-					this.theTab.getTabAt( theTab.getChildIndex( mmBox ) ).includeInLayout = false;
-				}
-				
-				if ( determineToShowProductsTab(requestCategory) && selectedExperiment.hasOwnProperty("@codeRequestStatus") && 
-					 selectedExperiment.@codeRequestStatus != "COMPLETE" && selectedExperiment.@codeRequestStatus != "FAILED") {
-					productsView.allowEdits(false);
-					productsView.refreshForRequestCategory(requestCategory);
-					productsView.refreshForLab(selectedExperiment.@idLab);
-					if (selectedExperiment.hasOwnProperty("@idProduct") && selectedExperiment.@idProduct != "") {
-						productsView.loadSelection(selectedExperiment.@idProduct, selectedExperiment.@idLab);
-					}
-					productsView.enabled = true;
-					this.theTab.getTabAt( theTab.getChildIndex( productsView ) ).visible = true;
-					this.theTab.getTabAt( theTab.getChildIndex( productsView ) ).includeInLayout = true;
-				} else {
-					productsView.reset();
-					productsView.allowEdits(false);
-					productsView.enabled = false;
-					this.theTab.getTabAt( theTab.getChildIndex( productsView ) ).visible = false;
-					this.theTab.getTabAt( theTab.getChildIndex( productsView ) ).includeInLayout = false;
-				}
-				
-				if (defaultTab == null) {
-					theTab.selectedIndex = 0;
-				} else {
-					theTab.selectedChild = defaultTab;
-					defaultTab = null;
-				}
-
-				//only keep unique appusers who have completed lib prep
-				libPrepCompletedBy = "";
-				var dict:Dictionary = new Dictionary();
-				for(var i:int = 0; i < samples.length; i++){
-					if(samples.getItemAt(i).@idLibPrepPerformedBy != ''){
-						var id:String = samples.getItemAt(i).@idLibPrepPerformedBy
-						dict[id] = id;
-					}
-				}
-				for each (var value:String in dict){
-					this.libPrepCompletedBy += parentApplication.dictionaryManager.xml.Dictionary.(@className == 'hci.gnomex.model.AppUserLite').DictionaryEntry.(@value != '' && @idAppUser == value).@display + '\n';
-				}
-
-				if(libPrepCompletedBy.length > 0){
-					libPrepCompletionBox.visible = true;
-				} else{
-					libPrepCompletionBox.visible = false;
-				}
-
-				placeSpecialQualColumns();
-
-				// Workflow progress
-				callLater(setWorkflowStatus);
-
-			}
-
-			private var qualFieldsInitialized:Boolean = false;
-			private var qualCalcConcentrationWasBefore:String;
-			private var qualRINNumberWasBefore:String;
-
-			/**
-			 *  Move the "QC Concentration" and "QC RIN" columns before "Seq Lib Protocol" for High Throughput Genomics
-			 *  Otherwise return these columns to their original positions (tracked by qualXxxxxWasBefore fields)
-			 */
-			private function placeSpecialQualColumns():void {
-				if (!qualFieldsInitialized) {
-					qualCalcConcentrationWasBefore = getFieldAfter("@qualCalcConcentration");
-					qualRINNumberWasBefore = getFieldAfter("@qualRINNumber");
-					qualFieldsInitialized = true;
-				}
-				if (isHighThroughputGenomics()) {
-					moveColumnBefore("@qualCalcConcentration", "@idSeqLibProtocol");
-					moveColumnBefore("@qualRINNumber", "@idSeqLibProtocol");
-				} else {
-					moveColumnBefore("@qualRINNumber", qualRINNumberWasBefore);
-					moveColumnBefore("@qualCalcConcentration", qualCalcConcentrationWasBefore);
-				}
-			}
-
-			private function isHighThroughputGenomics():Boolean {
-				return (this.selectedExperiment.@idCoreFacility == parentApplication.idCoreFacilityHTG);
-			}
-
-			private const MISSING_INDEX:int = -1;
-			private const MISSING_FIELD:String = "MISSING_FIELD";
-			private const LAST_FIELD:String = "LAST_FIELD";
-
-			private function getFieldAfter(field:String):String {
-				var column:int = getColumnIndexFromField(field);
-				if (column == MISSING_INDEX) {
-					return MISSING_FIELD;
-				}
-				if (column == samplesGridConfirm.columns.length - 1) {
-					return LAST_FIELD;
-				}
-				return samplesGridConfirm.columns[column + 1].dataField;
-			}
-
-			private function moveColumnBefore(moveField:String, otherField:String):void {
-				var moveFromColumn:int = getColumnIndexFromField(moveField);
-				if (moveFromColumn == MISSING_INDEX) {
-					return;
-				}
-				var columnsCopy:Array = samplesGridConfirm.columns;
-				var column:AdvancedDataGridColumn = columnsCopy.removeAt(moveFromColumn);
-				var moveToColumn:int;
-				var otherColumn:int = getColumnIndexFromFieldInArray(columnsCopy, otherField);
-				if (otherColumn != MISSING_INDEX) {
-					moveToColumn = otherColumn;
-				} else {
-					moveToColumn = moveFromColumn;
-				}
-				columnsCopy.insertAt(moveToColumn, column);
-				samplesGridConfirm.columns = columnsCopy;
-				samplesGridConfirm.validateNow();
-			}
-
-			private function getColumnIndexFromField(field:String):int {
-				return getColumnIndexFromFieldInArray(samplesGridConfirm.columns, field);
-			}
-
-			private function getColumnIndexFromFieldInArray(cols:Array, field:String):int {
-				if (field == LAST_FIELD) {
-					return cols.length;
-				}
-				for (var i:int; i < cols.length; i++) {
-					if (cols[i].dataField == field) {
-						return i;
-					}
-				}
-				return MISSING_INDEX;
-			}
-
-			private function shouldShowMMBox():Boolean {
-				if ( libDesignAndInsertBox.visible ){
-					return true;
-				}
-				if ( this.selectedExperiment.@codeIsolationPrepType != null && this.selectedExperiment.@codeIsolationPrepType!='' ) {
-					return true;
-				}
-				if ( this.selectedExperiment.protocols.Protocol.length() > 0 ) {
-					return true;
-				}
-				return false;
-			}
-
-			private function setWorkflowStatus():void {
-				// Reset the progress bar labels
-				for each(var stepLabelElement:Object in this.stepLabel) {
-					stepLabelElement.setStyle("fontWeight","normal");
-					stepLabelElement.setStyle("color","black");
-				}
-
-				var x:int = 0;
-				for each(var progressInfo:Object in selectedExperiment.workflowStatus.Progress) {
-					this.workflowProgressBar[x].setProgress(progressInfo.@stepNumber, selectedExperiment.workflowStatus.@numberOfSteps );
-					// Add style to labels for any step that has a sample(s) in that status
-					this.stepLabel[parseInt(progressInfo.@stepNumber)-1].setStyle("fontWeight","bold");
-					this.stepLabel[parseInt(progressInfo.@stepNumber)-1].setStyle("color","#2C9D11");
-					x++;
-				}
-
-				workflowProgressBox.visible = x > 0 ? true : false;
-				workflowProgressBox.includeInLayout = x > 0 ? true : false;
-			}
-
-			public function initializeBarcoding():void {
-				var showSampleMultiplexGroup:Boolean = false;
-				var showSampleBarcode:Boolean = false;
-				var showSampleBarcodeB:Boolean = false;
-				var showSampleCustomBarcode:Boolean = false;
-				var showSampleCustomBarcodeB:Boolean = false;
-				var showPlates:Boolean = false;
-				for each (var s:Object in samples) {
-					if (s.@multiplexGroupNumber != '' && !isNanoStringState()) {
-						showSampleMultiplexGroup = true;
-					}
-					if (((isCapSeqState() || isSequenomState()) && s.hasOwnProperty("@plateName") && s.@plateName != '') || isIScanState()) {
-						showPlates = true;
-					}
-					if (s.@idOligoBarcode != '' ) {
-						showSampleBarcode = true;
-					}
-					if (s.@barcodeSequence != '') {
-						showSampleCustomBarcode = true;
-					}
-					if(s.@idOligoBarcodeB != ''){
-						showSampleBarcodeB = true;
-					}
-					if(s.@barcodeSequenceB != ''){
-						showSampleCustomBarcodeB = true;
-					}
-				}
-
-				if (showPlates) {
-
-					this.samplesGridConfirm.dataProvider = null;
-					sampleGroupingCollection = new GroupingCollection();
-					sampleGroupingCollection.source = this.samples;
-					var groupCapSeq:Grouping = new Grouping();
-					var gfCapSeq:GroupingField = new GroupingField();
-					gfCapSeq.name = "@plateName";
-					groupCapSeq.fields = [gfCapSeq];
-					gfCapSeq.compareFunction = plateSampleCompareFunction;
-					sampleGroupingCollection.grouping  = groupCapSeq;
-					sampleGroupingCollection.refresh();
-					this.samplesGridConfirm.dataProvider = sampleGroupingCollection;
-
-					this.samplesGridConfirm.dragMoveEnabled = false;
-					this.samplesGridConfirm.dropEnabled = false;
-					this.samplesGridConfirm.dragEnabled = false;
-
-
-					this.switchFirstSampleGridColumns(this.plateNameCol, this.multiplexGroupNumberColumn);
-					this.plateNameCol.visible = true;
-					this.multiplexGroupNumberColumn.visible = false;
-
-				} else if (showSampleMultiplexGroup) {
-
-					this.samplesGridConfirm.dataProvider = null;
-					sampleGroupingCollection = new GroupingCollection();
-					sampleGroupingCollection.source = this.samples;
-					var group:Grouping = new Grouping();
-					var gf:GroupingField = new GroupingField();
-					gf.name = "@multiplexGroupNumber";
-					gf.compareFunction = sampleCompareFunction;
-					group.fields = [gf];
-					sampleGroupingCollection.grouping  = group;
-					sampleGroupingCollection.refresh();
-					this.samplesGridConfirm.dataProvider = sampleGroupingCollection;
-
-					this.multiplexGroupNumberColumn.visible = true;
-					switchFirstSampleGridColumns(this.multiplexGroupNumberColumn, this.plateNameCol);
-					this.plateNameCol.visible = false;
-
-				} else {
-
-					sampleGroupingCollection = null;
-					this.samplesGridConfirm.dataProvider = this.samples;
-
-					this.multiplexGroupNumberColumn.visible = false;
-
-				}
-
-				this.barcodeCol.visible = showSampleBarcode;
-				this.customBarcodeCol.visible = showSampleCustomBarcode;
-				this.customBarcodeColB.visible = showSampleCustomBarcodeB;
-				this.barcodeColB.visible = showSampleBarcodeB;
-
-				if (currentState == "SolexaState") {
-					this.laneBarcodeCol.visible = showSampleBarcode;
-					this.laneBarcodeColB.visible = showSampleBarcode;
-					this.laneCustomBarcodeCol.visible = showSampleCustomBarcode;
-					this.laneCustomBarcodeColB.visible = showSampleCustomBarcode;
-				}
-
-				this.samplesGridConfirm.validateNow();
-			}
-
-			private function switchFirstSampleGridColumns (col1:AdvancedDataGridColumn, col2:AdvancedDataGridColumn):void {
-				var columns:Array = [];
-				columns[0] = col1;
-				columns[1] = col2;
-				for(var i:int = 2;i < this.samplesGridConfirm.columns.length;i++) {
-					columns[i] = this.samplesGridConfirm.columns[i];
-				}
-				this.samplesGridConfirm.columns = columns;
-			}
-
-			private function sampleCompareFunction(a:XML, b:XML):int
-			{
+				return compVal;
+			} else {
 				var aPersistFlag:Number = 0;
 				var aPosition:Number = 0;
 				if (a.@idSample.toString().indexOf("Sample") > -1) {
@@ -752,390 +730,485 @@
 					return ObjectUtil.numericCompare(aPersistFlag, bPersistFlag);
 				}
 			}
+		}
 
-			private function plateSampleCompareFunction(a:XML, b:XML):int
-			{
-				if (a.hasOwnProperty("@plateName") && a.hasOwnProperty("@wellName") && b.hasOwnProperty("@plateName") && b.hasOwnProperty("@wellName")) {
-					var compVal:int = 0;
-					if (a.@plateName == b.@plateName) {
-						compVal = compVal = ObjectUtil.numericCompare(a.@wellName.toString().substr(1), b.@wellName.toString().substr(1));
-						if (compVal == 0) {
-							compVal = ObjectUtil.stringCompare(a.@wellName.toString(), b.@wellName.toString());
-						}
-					} else {
-						compVal = ObjectUtil.stringCompare(a.@plateName.toString(), b.@plateName.toString());
-					}
-					return compVal;
+		private function showCy3LabelCols(isVisible:Boolean):void {
+			labelCol1.visible = isVisible;
+			labelCol2.visible = isVisible;
+			labelCol3.visible = isVisible;
+			labelCol4.visible = isVisible;
+			labelCol5.visible = isVisible;
+		}
+
+		private function showCy5LabelCols(isVisible:Boolean):void {
+			labelCol6.visible = isVisible;
+			labelCol7.visible = isVisible;
+			labelCol8.visible = isVisible;
+			labelCol9.visible = isVisible;
+			labelCol10.visible = isVisible;
+		}
+
+		private function getChannel1SampleName(item:Object, col:int):String {
+			var de:XMLList = item.labeledSampleChannel1.LabeledSample.sample.Sample;
+			if (de.length() == 1) {
+				return de[0].@name;
+			} else {
+				return "";
+			}
+		}
+
+		private function getChannel2SampleName(item:Object, col:int):String {
+			var de:XMLList = item.labeledSampleChannel2.LabeledSample.sample.Sample;
+			if (de.length() == 1) {
+				return de[0].@name;
+			} else {
+				return "";
+			}
+		}
+
+		private function getChannel1SampleNumber(item:Object, col:int):String {
+			var de:XMLList = item.labeledSampleChannel1.LabeledSample.sample.Sample;
+			if (de.length() == 1) {
+				return de[0].@number;
+			} else {
+				return "";
+			}
+		}
+
+		private function getChannel2SampleNumber(item:Object, col:int):String {
+			var de:XMLList = item.labeledSampleChannel2.LabeledSample.sample.Sample;
+			if (de.length() == 1) {
+				return de[0].@number;
+			} else {
+				return "";
+			}
+		}
+
+		private function getHybsGridRowNumber(item:Object, col:int):String {
+			var x:int = hybsGridConfirm.dataProvider.getItemIndex(item) + 1;
+			return String(x);
+		}
+
+		private function getRequestCategoryVariables():void {
+			var requestCategory:Object = parentApplication.dictionaryManager.getEntry('hci.gnomex.model.RequestCategory', this.selectedExperiment.@codeRequestCategory);
+			if (requestCategory is XMLList) {
+				requestCategoryName = requestCategory[0].@display.toString();
+				if (requestCategory[0].@isClinicalResearch != null) {
+					isClinicalResearch = requestCategory[0].@isClinicalResearch.toString();
 				} else {
-					var aPersistFlag:Number = 0;
-					var aPosition:Number = 0;
-					if (a.@idSample.toString().indexOf("Sample") > -1) {
-						aPosition = a.@idSample.toString().substr(6);
-						aPersistFlag = 1;
-					} else {
-						aPosition = a.@idSample;
-					}
-
-					var bPersistFlag:Number = 0;
-					var bPosition:Number = 0;
-					if (b.@idSample.toString().indexOf("Sample") > -1) {
-						bPosition = b.@idSample.toString().substr(6);
-						bPersistFlag = 1; // non-persistent samples sort after the persistent ones
-					} else {
-						bPosition = b.@idSample;
-					}
-
-					if (aPersistFlag == bPersistFlag) {
-						return ObjectUtil.numericCompare(aPosition, bPosition);
-					} else {
-						return ObjectUtil.numericCompare(aPersistFlag, bPersistFlag);
-					}
+					isClinicalResearch = 'N'
 				}
-			}
-
-			private function showCy3LabelCols(isVisible:Boolean):void {
-				labelCol1.visible = isVisible;
-				labelCol2.visible = isVisible;
-				labelCol3.visible = isVisible;
-				labelCol4.visible = isVisible;
-				labelCol5.visible = isVisible;
-			}
-
-			private function showCy5LabelCols(isVisible:Boolean):void {
-				labelCol6.visible = isVisible;
-				labelCol7.visible = isVisible;
-				labelCol8.visible = isVisible;
-				labelCol9.visible = isVisible;
-				labelCol10.visible = isVisible;
-			}
-
-			private function getChannel1SampleName(item:Object, col:int):String {
-				var de:XMLList = item.labeledSampleChannel1.LabeledSample.sample.Sample;
-				if (de.length() == 1) {
-					return de[0].@name;
+			} else {
+				requestCategoryName = requestCategory.@display.toString();
+				if (requestCategory.@isClinicalResearch != null) {
+					isClinicalResearch = requestCategory.@isClinicalResearch.toString();
 				} else {
-					return "";
+					isClinicalResearch = 'N'
 				}
 			}
-			private function getChannel2SampleName(item:Object, col:int):String {
-				var de:XMLList = item.labeledSampleChannel2.LabeledSample.sample.Sample;
-				if (de.length() == 1) {
-					return de[0].@name;
+		}
+
+		private function getExperimentCategoryName():void {
+			experimentCategoryName = "";
+			if (this.selectedExperiment.protocols.Protocol.length() <= 0 || !this.headerBox.visible) {
+				var experimentCategory:Object = parentApplication.dictionaryManager.getEntry('hci.gnomex.model.Application', this.selectedExperiment.@codeApplication);
+				if (experimentCategory is XMLList) {
+					experimentCategoryName = experimentCategory[0].@display.toString();
 				} else {
-					return "";
+					experimentCategoryName = experimentCategory.@display.toString();
+				}
+				if (this.selectedExperiment.@codeApplication == 'OTHER' && this.selectedExperiment.@applicationNotes != '') {
+					experimentCategoryName += ' - ' + this.selectedExperiment.@applicationNotes;
 				}
 			}
-			private function getChannel1SampleNumber(item:Object, col:int):String {
-				var de:XMLList = item.labeledSampleChannel1.LabeledSample.sample.Sample;
-				if (de.length() == 1) {
-					return de[0].@number;
+		}
+
+		private function getVisibilityName():void {
+			if (selectedExperiment.hasOwnProperty("@codeVisibility")) {
+				var visibility:Object = parentApplication.dictionaryManager.getEntry('hci.gnomex.model.Visibility', this.selectedExperiment.@codeVisibility);
+				if (visibility is XMLList) {
+					visibilityName = visibility[0].@display.toString();
 				} else {
-					return "";
+					visibilityName = visibility.@display.toString();
 				}
 			}
-			private function getChannel2SampleNumber(item:Object, col:int):String {
-				var de:XMLList = item.labeledSampleChannel2.LabeledSample.sample.Sample;
-				if (de.length() == 1) {
-					return de[0].@number;
+		}
+
+		private function getInstitutionName():void {
+			if (selectedExperiment.hasOwnProperty("@idInstitution")) {
+				var institution:Object = parentApplication.dictionaryManager.getEntry('hci.gnomex.model.Institution', this.selectedExperiment.@idInstitution);
+				if (institution is XMLList) {
+					institutionName = institution[0].@display.toString();
 				} else {
-					return "";
+					institutionName = institution.@display.toString();
 				}
 			}
-			private function getHybsGridRowNumber(item:Object,col:int):String
-			{
-				var x:int = hybsGridConfirm.dataProvider.getItemIndex(item) + 1;
-				return String(x);
+		}
+
+		public function showDownloads():void {
+			this.theTab.selectedChild = this.filesView;
+			downloadExpandedFilesButtonView.visible = true;
+			downloadExpandedFilesButtonView.includeInLayout = true;
+		}
+
+		public function promptToDeleteExperiment():void {
+			var warningMessage:String = "Delete experiment " + this.selectedExperiment.@number + "?";
+
+			var billingItems:XMLList = this.selectedExperiment.billingItems.BillingItem;
+			if (billingItems.length() > 0) {
+				warningMessage += "\n\nWARNING: This will also delete " + billingItems.length() + " billing item(s) associated with this experiment.\n\n";
 			}
 
-			private function getRequestCategoryVariables():void {
-				var requestCategory:Object = parentApplication.dictionaryManager.getEntry('hci.gnomex.model.RequestCategory', this.selectedExperiment.@codeRequestCategory);
-				if (requestCategory is XMLList) {
-					requestCategoryName = requestCategory[0].@display.toString();
-					if (requestCategory[0].@isClinicalResearch != null) {
-						isClinicalResearch = requestCategory[0].@isClinicalResearch.toString();
-					} else {
-						isClinicalResearch = 'N'
-					}
-				} else {
-					requestCategoryName = requestCategory.@display.toString();
-					if (requestCategory.@isClinicalResearch != null) {
-						isClinicalResearch = requestCategory.@isClinicalResearch.toString();
-					} else {
-						isClinicalResearch = 'N'
-					}
-				}
-			}
-
-			private function getExperimentCategoryName():void {
-				experimentCategoryName = "";
-				if (this.selectedExperiment.protocols.Protocol.length() <= 0 || !this.headerBox.visible) {
-					var experimentCategory:Object = parentApplication.dictionaryManager.getEntry('hci.gnomex.model.Application', this.selectedExperiment.@codeApplication);
-					if (experimentCategory is XMLList) {
-						experimentCategoryName  = experimentCategory[0].@display.toString();
-					} else {
-						experimentCategoryName = experimentCategory.@display.toString();
-					}
-					if ( this.selectedExperiment.@codeApplication == 'OTHER' && this.selectedExperiment.@applicationNotes != '' ) {
-						experimentCategoryName += ' - ' + this.selectedExperiment.@applicationNotes;
-					}
+			var statusToUseProducts:String = parentApplication.getRequestCategoryProperty(selectedExperiment.@idCoreFacility, selectedExperiment.@codeRequestCategory, parentApplication.PROPERTY_STATUS_TO_USE_PRODUCTS);
+			if (statusToUseProducts != null && statusToUseProducts != "" && selectedExperiment.hasOwnProperty("@codeRequestStatus") && selectedExperiment.@codeRequestStatus != "") {
+				var comp:RequestStatusComparator = new RequestStatusComparator();
+				if (comp.compare(selectedExperiment.@codeRequestStatus, statusToUseProducts) >= 0) {
+					warningMessage += "\n\nWARNING: This experiment may have used products. If the products were not actually consumed, please revert the status of the experiment to an earlier status or manually return the products to the lab before deleting.\n\n";
 				}
 			}
 
-			private function getSeqLibTreatments():void {
-				seqLibTreatments = "";
-				for each(var item:Object in this.selectedExperiment.seqLibTreatments.SeqLibTreatment) {
-					if (seqLibTreatments.length > 0) {
-						seqLibTreatments += ", ";
-					}
-					seqLibTreatments += item.@display;
+			Alert.show(warningMessage,
+					"Confirm",
+					(Alert.YES | Alert.NO), this,
+					onPromptToDeleteExperiment);
+		}
+
+		private function onPromptToDeleteExperiment(event:CloseEvent):void {
+			if (event.detail == Alert.YES) {
+				deleteExperiment();
+			}
+		}
+
+		private function deleteExperiment():void {
+			parentDocument.parentDocument.deleteExperiment();
+		}
+
+		public function promptToSubmitExperiment():void {
+			if (this.productsView.enabled) {
+				var error:String = this.productsView.getErrors("submit");
+				if (error != "") {
+					Alert.show(error);
+					return;
 				}
 			}
-			private function getVisibilityName():void {
-				if (selectedExperiment.hasOwnProperty("@codeVisibility")) {
-					var visibility:Object = parentApplication.dictionaryManager.getEntry('hci.gnomex.model.Visibility', this.selectedExperiment.@codeVisibility);
-					if (visibility is XMLList) {
-						visibilityName = visibility[0].@display.toString();
-					} else {
-						visibilityName = visibility.@display.toString();
-					}
+			Alert.show("Submit experiment " + this.selectedExperiment.@number + "?  After submission only facility personnel will be able to make changes.",
+					"Confirm",
+					(Alert.YES | Alert.NO), this,
+					onPromptToSubmitExperiment);
+		}
+
+		private function onPromptToSubmitExperiment(event:CloseEvent):void {
+			if (event.detail == Alert.YES) {
+				submitExperiment();
+			}
+		}
+
+		private function submitExperiment():void {
+			parentDocument.parentDocument.submitExperiment();
+		}
+
+		public function promptToArchiveExperiment():void {
+			Alert.show("Archive experiment " + this.selectedExperiment.@number + "?  Archiving an experiment will delete all files on disk associated with this experiment and it will no longer appear in browse experiment lists.  However, GNomEx will retain a record of the experiment/sample details if you wish to restore them at a later date.",
+					"Confirm",
+					(Alert.YES | Alert.NO), this,
+					onPromptToArchiveExperiment);
+
+		}
+
+		private function onPromptToArchiveExperiment(event:CloseEvent):void {
+			if (event.detail == Alert.YES) {
+				parentDocument.parentDocument.archiveExperiment();
+			}
+		}
+
+		public function showPrintableRequestForm():void {
+			var url:URLRequest = new URLRequest('ShowRequestForm.gx?idRequest=' + this.selectedExperiment.@idRequest);
+			navigateToURL(url, '_blank');
+		}
+
+		public function checkForFileView():void {
+			if (theTab.contains(this.filesView)) {
+				theTab.selectedChild = filesView;
+				callLater(filesView.showDownloadWindow);
+			}
+		}
+
+		public function showEditExperimentWindow():void {
+			parentDocument.parentDocument.experimentEditView.instantiateTabs(this.selectedExperiment.@codeRequestCategory, true, false);
+			parentDocument.parentDocument.experimentEditView.coreFacility = parentApplication.dictionaryManager.getEntry('hci.gnomex.model.CoreFacility', this.selectedExperiment.@idCoreFacility);
+
+			parentDocument.parentDocument.experimentEditView.request = this.selectedExperiment;
+			parentDocument.parentDocument.experimentEditView.coreFacility = parentApplication.dictionaryManager.getEntry('hci.gnomex.model.CoreFacility', this.selectedExperiment.@idCoreFacility);
+			parentDocument.parentDocument.experimentEditView.samplesView.setShowCCNumber(this.selectedExperiment.@hasCCNumber == 'Y');
+			parentDocument.parentDocument.experimentEditView.selectedAssaysCollection = this.assays;
+			parentDocument.parentDocument.experimentEditView.saveDescription = GNomExStringUtil.cleanRichTextHTML(this.overallDescript.htmlText);
+
+			parentDocument.parentDocument.experimentViews.selectedChild = parentDocument.parentDocument.experimentEditView;
+			if (parentDocument.parentDocument.experimentEditView.theTab.contains(parentDocument.parentDocument.experimentEditView.annotationView)) {
+				parentDocument.parentDocument.experimentEditView.annotationView.onPropertyRefreshed(null);
+				parentDocument.parentDocument.experimentEditView.annotationView.checkSecurity();
+			}
+
+			if (this.isCherryPickState()) {
+				var numDestinationWells:int = Number(this.selectedExperiment.@numDestinationWells.toString());
+				parentDocument.parentDocument.experimentEditView.cherryPlateList = this.selectedExperiment.cherryPlateList.Plate;
+				parentDocument.parentDocument.experimentEditView.samplesView.prepareCherryPickingSamplesForEdit(numDestinationWells);
+			}
+
+			if (this.isIScanState() || (this.isSequenomState() && this.selectedExperiment.@containerType == "PLATE")) {
+				parentDocument.parentDocument.experimentEditView.numIScanPlates = countPlates();
+			}
+
+			var editTitle:String = (this.selectedExperiment.@isExternal == 'Y' ? 'Edit External Experiment ' : 'Edit Experiment ') + this.selectedExperiment.@number;
+
+			parentDocument.parentDocument.experimentEditView.removeDataListeners();
+			parentDocument.parentDocument.experimentEditView.initializeData();
+
+			// ********************************************************************************
+			parentApplication.lastGetRequestDownloadListidRequest = "";
+			parentApplication.lastGetRequestDownloadListrequestNumber = "";
+
+			parentDocument.parentDocument.experimentEditView.setupEditForm(this.selectedExperiment);
+			parentDocument.parentDocument.experimentEditView.titleLabel.text = editTitle;
+
+			if (parentDocument.parentDocument.experimentEditView.samplesView.hasPlates() && !parentDocument.parentDocument.experimentEditView.isIScanState()
+					&& !parentDocument.parentDocument.experimentEditView.isSequenomState()) {
+				parentDocument.parentDocument.experimentEditView.numCapSeqPlates = countPlates();
+			}
+
+			chooseEditTabs();
+			callLater(parentDocument.parentDocument.experimentEditView.setupDataListeners);
+
+		}
+
+		private function chooseEditTabs():void {
+			chooseEditTab(infoTab, parentDocument.parentDocument.experimentEditView.infoTab);
+			chooseEditTab(notesTab, parentDocument.parentDocument.experimentEditView.notesView);
+			chooseEditTab(samplesTab, parentDocument.parentDocument.experimentEditView.samplesView);
+			chooseEditTab(lanesConfirmContainer, parentDocument.parentDocument.experimentEditView.lanesView);
+			chooseEditTab(bioinformaticsTab, parentDocument.parentDocument.experimentEditView.bioinformaticsView);
+			chooseEditTab(filesView, parentDocument.parentDocument.experimentEditView.downloadView);
+		}
+
+		private function chooseEditTab(selectedTab:Object, parentTab:Container):void {
+			if (theTab.selectedChild == selectedTab && parentDocument.parentDocument.experimentEditView.theTab.contains(parentTab)) {
+				parentDocument.parentDocument.experimentEditView.defaultTab = parentTab;
+			}
+		}
+
+		private function countPlates():int {
+			var prevPlate:String = "xxxx";
+			var numPlates:int = 0;
+			for each (var s:Object in this.samples) {
+				if (s.@plateName != prevPlate) {
+					numPlates++;
 				}
+				prevPlate = s.@plateName;
 			}
 
-			private function getInstitutionName():void {
-				if (selectedExperiment.hasOwnProperty("@idInstitution")) {
-					var institution:Object = parentApplication.dictionaryManager.getEntry('hci.gnomex.model.Institution', this.selectedExperiment.@idInstitution);
-					if (institution is XMLList) {
-						institutionName = institution[0].@display.toString();
-					} else {
-						institutionName = institution.@display.toString();
-					}
-				}
-			}
+			return numPlates;
+		}
 
-			public function showDownloads():void {
-				this.theTab.selectedChild = this.filesView;
-				downloadExpandedFilesButtonView.visible = true;
-				downloadExpandedFilesButtonView.includeInLayout = true;
-			}
+		public function refreshSavedExperiment(idRequest:Object):void {
+			parentDocument.parentDocument.selectedIdRequest = idRequest;
+			var parms:Object = {};
+			parms.idRequest = parentDocument.parentDocument.selectedIdRequest;
+			parentDocument.parentDocument.getRequest.send(parms);
 
-			public function promptToDeleteExperiment():void {
-				var warningMessage:String = "Delete experiment " + this.selectedExperiment.@number + "?";
+		}
 
-				var billingItems:XMLList = this.selectedExperiment.billingItems.BillingItem;
-				if ( billingItems.length() > 0) {
-					warningMessage += "\n\nWARNING: This will also delete " + billingItems.length() + " billing item(s) associated with this experiment.\n\n";
-				}
+		public function getLanesGridRowNumber(item:Object, col:int):String {
+			var x:int = this.lanesConfirmGrid.dataProvider.getItemIndex(item) + 1;
+			return String(x);
+		}
 
-				var statusToUseProducts:String = parentApplication.getRequestCategoryProperty(selectedExperiment.@idCoreFacility, selectedExperiment.@codeRequestCategory, parentApplication.PROPERTY_STATUS_TO_USE_PRODUCTS);
-				if (statusToUseProducts != null && statusToUseProducts != "" && selectedExperiment.hasOwnProperty("@codeRequestStatus") && selectedExperiment.@codeRequestStatus != "") {
-					var comp:RequestStatusComparator = new RequestStatusComparator();
-					if (comp.compare(selectedExperiment.@codeRequestStatus, statusToUseProducts) >= 0) {
-						warningMessage += "\n\nWARNING: This experiment may have used products. If the products were not actually consumed, please revert the status of the experiment to an earlier status or manually return the products to the lab before deleting.\n\n";
-					}
-				}
+		private function showHideColumns():void {
+			descriptionCol.visible = (this.selectedExperiment.@hasSampleDescription == "Y");
+			this.cherryDestinationWellCol.visible = false;
+			this.cherrySourcePlateCol.visible = false;
+			this.cherrySourceWellCol.visible = false;
+			this.sampleSourceCol.visible = false;
+			applicationCol.visible = false;
+			reactionPlateCol.visible = false;
+			redoFlagCol.visible = false;
+			this.sampleNameColumn.visible = true;
+			qubitConcentrationCol.visible = (this.selectedExperiment.@includeQubitConcentration == "Y");
 
-				Alert.show(warningMessage,
-						"Confirm",
-						(Alert.YES | Alert.NO), this,
-						onPromptToDeleteExperiment);
-			}
+			this.getConcentrationHeader();
+			// can't do this in state stuff because of external stuff below.
+			this.noteToCoreFacilityBox.visible = true;
+			this.noteToCoreFacilityBox.includeInLayout = true;
 
-			private function onPromptToDeleteExperiment(event:CloseEvent):void {
-				if (event.detail==Alert.YES) {
-					deleteExperiment();
-				}
-			}
-			private function deleteExperiment():void {
-				parentDocument.parentDocument.deleteExperiment();
-			}
-
-			public function promptToSubmitExperiment():void {
-				if(this.productsView.enabled){
-					var error:String = this.productsView.getErrors("submit");
-					if(error != ""){
-						Alert.show(error);
-						return;
-					}
-				}
-				Alert.show("Submit experiment " + this.selectedExperiment.@number + "?  After submission only facility personnel will be able to make changes.",
-						"Confirm",
-						(Alert.YES | Alert.NO), this,
-						onPromptToSubmitExperiment);
-			}
-
-			private function onPromptToSubmitExperiment(event:CloseEvent):void {
-				if (event.detail==Alert.YES) {
-					submitExperiment();
-				}
-			}
-			private function submitExperiment():void {
-				parentDocument.parentDocument.submitExperiment();
-			}
-
-			public function promptToArchiveExperiment():void{
-				Alert.show("Archive experiment " + this.selectedExperiment.@number + "?  Archiving an experiment will delete all files on disk associated with this experiment and it will no longer appear in browse experiment lists.  However, GNomEx will retain a record of the experiment/sample details if you wish to restore them at a later date.",
-						"Confirm",
-						(Alert.YES | Alert.NO), this,
-						onPromptToArchiveExperiment);
-
-			}
-
-			private function onPromptToArchiveExperiment(event:CloseEvent):void{
-				if (event.detail==Alert.YES) {
-					parentDocument.parentDocument.archiveExperiment();
-				}
-			}
-
-			public function showPrintableRequestForm():void {
-				var url:URLRequest = new URLRequest('ShowRequestForm.gx?idRequest=' + this.selectedExperiment.@idRequest);
-				navigateToURL(url, '_blank');
-			}
-
-			public function checkForFileView():void {
-				if(theTab.contains(this.filesView)) {
-					theTab.selectedChild = filesView;
-					callLater(filesView.showDownloadWindow);
-				}
-			}
-
-			public function showEditExperimentWindow():void {
-				parentDocument.parentDocument.experimentEditView.instantiateTabs(this.selectedExperiment.@codeRequestCategory, true, false);
-				parentDocument.parentDocument.experimentEditView.coreFacility = parentApplication.dictionaryManager.getEntry('hci.gnomex.model.CoreFacility', this.selectedExperiment.@idCoreFacility);
-
-				parentDocument.parentDocument.experimentEditView.request = this.selectedExperiment;
-				parentDocument.parentDocument.experimentEditView.coreFacility = parentApplication.dictionaryManager.getEntry('hci.gnomex.model.CoreFacility', this.selectedExperiment.@idCoreFacility);
-				parentDocument.parentDocument.experimentEditView.samplesView.setShowCCNumber(this.selectedExperiment.@hasCCNumber == 'Y');
-				parentDocument.parentDocument.experimentEditView.selectedAssaysCollection = this.assays;
-				parentDocument.parentDocument.experimentEditView.saveDescription = GNomExStringUtil.cleanRichTextHTML(this.overallDescript.htmlText);
-
-				parentDocument.parentDocument.experimentViews.selectedChild = parentDocument.parentDocument.experimentEditView;
-				if (parentDocument.parentDocument.experimentEditView.theTab.contains(parentDocument.parentDocument.experimentEditView.annotationView)) {
-					parentDocument.parentDocument.experimentEditView.annotationView.onPropertyRefreshed(null);
-					parentDocument.parentDocument.experimentEditView.annotationView.checkSecurity();
-				}
-
-				if (this.isCherryPickState()) {
-					var numDestinationWells:int = Number(this.selectedExperiment.@numDestinationWells.toString());
-					parentDocument.parentDocument.experimentEditView.cherryPlateList = this.selectedExperiment.cherryPlateList.Plate;
-					parentDocument.parentDocument.experimentEditView.samplesView.prepareCherryPickingSamplesForEdit(numDestinationWells);
-				}
-
-				if (this.isIScanState() || (this.isSequenomState() && this.selectedExperiment.@containerType == "PLATE") ) {
-					parentDocument.parentDocument.experimentEditView.numIScanPlates = countPlates();
-				}
-
-				var editTitle:String = (this.selectedExperiment.@isExternal == 'Y' ? 'Edit External Experiment ' :  'Edit Experiment ') + this.selectedExperiment.@number;
-
-				parentDocument.parentDocument.experimentEditView.removeDataListeners();
-				parentDocument.parentDocument.experimentEditView.initializeData();
-
-				// ********************************************************************************
-				parentApplication.lastGetRequestDownloadListidRequest = "";
-				parentApplication.lastGetRequestDownloadListrequestNumber = "";
-
-				parentDocument.parentDocument.experimentEditView.setupEditForm(this.selectedExperiment);
-				parentDocument.parentDocument.experimentEditView.titleLabel.text = editTitle;
-
-				if (parentDocument.parentDocument.experimentEditView.samplesView.hasPlates() && !parentDocument.parentDocument.experimentEditView.isIScanState()
-						&& !parentDocument.parentDocument.experimentEditView.isSequenomState() ) {
-					parentDocument.parentDocument.experimentEditView.numCapSeqPlates = countPlates();
-				}
-
-				chooseEditTabs();
-				callLater(parentDocument.parentDocument.experimentEditView.setupDataListeners);
-
-			}
-
-			private function chooseEditTabs():void {
-				chooseEditTab(infoTab, parentDocument.parentDocument.experimentEditView.infoTab);
-				chooseEditTab(notesTab, parentDocument.parentDocument.experimentEditView.notesView);
-				chooseEditTab(samplesTab, parentDocument.parentDocument.experimentEditView.samplesView);
-				chooseEditTab(lanesConfirmContainer, parentDocument.parentDocument.experimentEditView.lanesView);
-				chooseEditTab(bioinformaticsTab, parentDocument.parentDocument.experimentEditView.bioinformaticsView);
-				chooseEditTab(filesView, parentDocument.parentDocument.experimentEditView.downloadView);
-			}
-
-			private function chooseEditTab(selectedTab:Object, parentTab:Container):void {
-				if (theTab.selectedChild == selectedTab && parentDocument.parentDocument.experimentEditView.theTab.contains(parentTab)) {
-					parentDocument.parentDocument.experimentEditView.defaultTab = parentTab;
-				}
-			}
-
-			private function countPlates():int {
-				var prevPlate:String = "xxxx";
-				var numPlates:int = 0;
-				for each (var s:Object in this.samples) {
-					if (s.@plateName != prevPlate) {
-						numPlates++;
-					}
-					prevPlate = s.@plateName;
-				}
-
-				return numPlates;
-			}
-
-			public function refreshSavedExperiment(idRequest:Object):void {
-				parentDocument.parentDocument.selectedIdRequest = idRequest;
-				var parms:Object = new Object();
-				parms.idRequest = parentDocument.parentDocument.selectedIdRequest;
-				parentDocument.parentDocument.getRequest.send(parms);
-
-			}
-
-			public function getLanesGridRowNumber(item:Object,col:int):String
-			{
-				var x:int = this.lanesConfirmGrid.dataProvider.getItemIndex(item) + 1;
-				return String(x);
-			}
-
-			private function showHideColumns():void {
-				descriptionCol.visible = (this.selectedExperiment.@hasSampleDescription=="Y");
-				this.cherryDestinationWellCol.visible = false;
-				this.cherrySourcePlateCol.visible = false;
-				this.cherrySourceWellCol.visible = false;
-				this.sampleSourceCol.visible = false;
-				applicationCol.visible = false;
-				reactionPlateCol.visible = false;
-				redoFlagCol.visible = false;
-				this.sampleNameColumn.visible = true;
-				qubitConcentrationCol.visible = (this.selectedExperiment.@includeQubitConcentration=="Y");
-
-				this.getConcentrationHeader();
-				// can't do this in state stuff because of external stuff below.
-				this.noteToCoreFacilityBox.visible = true;
-				this.noteToCoreFacilityBox.includeInLayout = true;
-
-				// hide bio and core notes for external experiments unless populated.
-				if (this.selectedExperiment.@isExternal == "Y") {
-					if (this.noteToCoreFacilityBox.visible) {
-						if (this.selectedExperiment.@corePrepInstructions == null || this.selectedExperiment.@corePrepInstructions == "") {
-							this.noteToCoreFacilityBox.visible = false;
-							this.noteToCoreFacilityBox.includeInLayout = false;
-						}
+			// hide bio and core notes for external experiments unless populated.
+			if (this.selectedExperiment.@isExternal == "Y") {
+				if (this.noteToCoreFacilityBox.visible) {
+					if (this.selectedExperiment.@corePrepInstructions == null || this.selectedExperiment.@corePrepInstructions == "") {
+						this.noteToCoreFacilityBox.visible = false;
+						this.noteToCoreFacilityBox.includeInLayout = false;
 					}
 				}
+			}
 
-				// Make description bigger if possible
-				if (!this.noteToCoreFacilityBox.visible) {
-					this.bioAndCoreNoteVBox.visible = false;
-					this.bioAndCoreNoteVBox.includeInLayout = false;
-				} else {
-					this.bioAndCoreNoteVBox.visible = true;
-					this.bioAndCoreNoteVBox.includeInLayout = true;
-				}
+			// Make description bigger if possible
+			if (!this.noteToCoreFacilityBox.visible) {
+				this.bioAndCoreNoteVBox.visible = false;
+				this.bioAndCoreNoteVBox.includeInLayout = false;
+			} else {
+				this.bioAndCoreNoteVBox.visible = true;
+				this.bioAndCoreNoteVBox.includeInLayout = true;
+			}
 
-				if (currentState == 'ExternalSeqState') {
+			if (currentState == 'ExternalSeqState') {
+				sampleTypeCol.visible = true;
+				organismCol.visible = false;
+				sampleVolumeCol.visible = false;
+
+				this.otherOrganismCol.visible = false;
+				this.otherSamplePrepMethodCol.visible = false;
+				concentrationCol.visible = false;
+				preppedByLabCol.visible = false;
+				chipTypeCol.visible = false;
+				concentrationUnitCol.visible = false;
+				barcodeCol.visible = false;
+				plateNameCol.visible = false;
+				wellNameCol.visible = false;
+				isControlCol.visible = false;
+				this.qc260Col.visible = false;
+				this.qc260280Col.visible = false;
+				this.qcConcCol.visible = false;
+				this.qcRINCol.visible = false;
+				this.qcStatusCol.visible = false;
+
+			} else if (currentState == 'ExternalMicroarrayState') {
+				sampleTypeCol.visible = true;
+				organismCol.visible = false;
+				sampleVolumeCol.visible = false;
+
+				this.otherOrganismCol.visible = false;
+				this.otherSamplePrepMethodCol.visible = false;
+				concentrationCol.visible = false;
+				preppedByLabCol.visible = false;
+				chipTypeCol.visible = false;
+				concentrationUnitCol.visible = false;
+				barcodeCol.visible = false;
+				plateNameCol.visible = false;
+				wellNameCol.visible = false;
+				isControlCol.visible = false;
+				this.qc260Col.visible = false;
+				this.qc260280Col.visible = false;
+				this.qcConcCol.visible = false;
+				this.qcRINCol.visible = false;
+				this.qcStatusCol.visible = false;
+
+			} else {
+
+				descriptionCol.visible = true;
+
+				if (currentState == 'SolexaState') {
+					concentrationCol.visible = true;
+					sampleVolumeCol.visible = true;
 					sampleTypeCol.visible = true;
-					organismCol.visible = false;
-					sampleVolumeCol.visible = false;
-
-					this.otherOrganismCol.visible = false;
-					this.otherSamplePrepMethodCol.visible = false;
-					concentrationCol.visible = false;
-					preppedByLabCol.visible = false;
+					organismCol.visible = true;
+					preppedByLabCol.visible = true;
+					otherSamplePrepMethodCol.visible = true;
 					chipTypeCol.visible = false;
 					concentrationUnitCol.visible = false;
-					barcodeCol.visible = false;
+					plateNameCol.visible = false;
+					wellNameCol.visible = false;
+					isControlCol.visible = false;
+					this.qc260Col.visible = false;
+					this.qc260280Col.visible = false;
+					this.qcConcCol.visible = true;
+					this.qcRINCol.visible = true;
+					this.qcStatusCol.visible = true;
+					descriptionCol.visible = false;
+
+				} else if (currentState == 'QCState' || currentState == 'ExternalQCState') {
+					sampleVolumeCol.visible = false;
+					concentrationCol.visible = false;
+					sampleTypeCol.visible = false;
+					organismCol.visible = false;
+					preppedByLabCol.visible = false;
+					otherSamplePrepMethodCol.visible = true;
+					var application:Object = parentApplication.dictionaryManager.getEntry('hci.gnomex.model.Application', this.selectedExperiment.@codeApplication);
+					chipTypeCol.visible = (!!(application != null && application.@hasChipTypes == 'Y'));
+					concentrationUnitCol.visible = true;
+					plateNameCol.visible = false;
+					wellNameCol.visible = false;
+					isControlCol.visible = false;
+					this.qc260Col.visible = true;
+					this.qc260280Col.visible = false;
+					this.qcConcCol.visible = true;
+					this.qcRINCol.visible = true;
+					this.qcStatusCol.visible = currentState == 'QCState';
+				} else if (isCapSeqState()) {
+					sampleVolumeCol.visible = false;
+					concentrationCol.visible = false;
+					sampleTypeCol.visible = true;
+					organismCol.visible = false;
+					preppedByLabCol.visible = false;
+					otherSamplePrepMethodCol.visible = false;
+					chipTypeCol.visible = false;
+					concentrationUnitCol.visible = false;
+					plateNameCol.visible = (this.selectedExperiment.@containerType == "PLATE");
+					wellNameCol.visible = (this.selectedExperiment.@containerType == "PLATE");
+					isControlCol.visible = (this.selectedExperiment.@containerType == "PLATE");
+					this.qc260Col.visible = false;
+					this.qc260280Col.visible = false;
+					this.qcConcCol.visible = false;
+					this.qcRINCol.visible = false;
+					this.qcStatusCol.visible = false;
+					reactionPlateCol.visible = true;
+					redoFlagCol.visible = true;
+					this.descriptionCol.visible = false;
+
+				} else if (isMitSeqState()) {
+					sampleVolumeCol.visible = false;
+					concentrationCol.visible = false;
+					sampleTypeCol.visible = false;
+					organismCol.visible = false;
+					preppedByLabCol.visible = false;
+					otherSamplePrepMethodCol.visible = false;
+					chipTypeCol.visible = false;
+					concentrationUnitCol.visible = false;
+					plateNameCol.visible = false;
+					wellNameCol.visible = true;
+					isControlCol.visible = false;
+					this.qc260Col.visible = false;
+					this.qc260280Col.visible = false;
+					this.qcConcCol.visible = false;
+					this.qcRINCol.visible = false;
+					this.qcStatusCol.visible = false;
+					reactionPlateCol.visible = true;
+					redoFlagCol.visible = true;
+
+				} else if (isFragAnalState()) {
+					sampleVolumeCol.visible = false;
+					concentrationCol.visible = false;
+					sampleTypeCol.visible = false;
+					organismCol.visible = false;
+					preppedByLabCol.visible = false;
+					otherSamplePrepMethodCol.visible = false;
+					chipTypeCol.visible = false;
+					concentrationUnitCol.visible = false;
+					plateNameCol.visible = false;
+					wellNameCol.visible = true;
+					isControlCol.visible = false;
+					this.qc260Col.visible = false;
+					this.qc260280Col.visible = false;
+					this.qcConcCol.visible = false;
+					this.qcRINCol.visible = false;
+					this.qcStatusCol.visible = false;
+					reactionPlateCol.visible = true;
+				} else if (isCherryPickState()) {
+					sampleVolumeCol.visible = false;
+					concentrationCol.visible = false;
+					sampleTypeCol.visible = false;
+					organismCol.visible = false;
+					preppedByLabCol.visible = false;
+					otherSamplePrepMethodCol.visible = false;
+					chipTypeCol.visible = false;
+					concentrationUnitCol.visible = false;
 					plateNameCol.visible = false;
 					wellNameCol.visible = false;
 					isControlCol.visible = false;
@@ -1144,19 +1217,126 @@
 					this.qcConcCol.visible = false;
 					this.qcRINCol.visible = false;
 					this.qcStatusCol.visible = false;
+					this.cherryDestinationWellCol.visible = true;
+					this.cherrySourcePlateCol.visible = true;
+					this.cherrySourceWellCol.visible = true;
+					reactionPlateCol.visible = true;
 
-				} else if (currentState == 'ExternalMicroarrayState') {
-					sampleTypeCol.visible = true;
-					organismCol.visible = false;
+				} else if (isIScanState()) {
 					sampleVolumeCol.visible = false;
-
-					this.otherOrganismCol.visible = false;
-					this.otherSamplePrepMethodCol.visible = false;
 					concentrationCol.visible = false;
+					sampleTypeCol.visible = false;
+					organismCol.visible = false;
 					preppedByLabCol.visible = false;
+					otherSamplePrepMethodCol.visible = false;
 					chipTypeCol.visible = false;
 					concentrationUnitCol.visible = false;
-					barcodeCol.visible = false;
+					plateNameCol.visible = false;
+					wellNameCol.visible = true;
+					isControlCol.visible = false;
+					this.qc260Col.visible = false;
+					this.qc260280Col.visible = false;
+					this.qcConcCol.visible = false;
+					this.qcRINCol.visible = false;
+					this.qcStatusCol.visible = false;
+					this.cherryDestinationWellCol.visible = false;
+					this.cherrySourcePlateCol.visible = false;
+					this.cherrySourceWellCol.visible = false;
+					reactionPlateCol.visible = false;
+					this.descriptionCol.visible = false;
+
+				} else if (isSequenomState()) {
+					sampleVolumeCol.visible = false;
+					concentrationCol.visible = true;
+					sampleTypeCol.visible = true;
+					organismCol.visible = false;
+					preppedByLabCol.visible = false;
+					otherSamplePrepMethodCol.visible = false;
+					chipTypeCol.visible = false;
+					concentrationUnitCol.visible = false;
+					plateNameCol.visible = (this.selectedExperiment.@containerType == "PLATE");
+					wellNameCol.visible = (this.selectedExperiment.@containerType == "PLATE");
+					isControlCol.visible = false;
+					this.qc260Col.visible = false;
+					this.qc260280Col.visible = true;
+					this.qcConcCol.visible = false;
+					this.qcRINCol.visible = false;
+					this.qcStatusCol.visible = false;
+					this.descriptionCol.visible = false;
+
+				} else if (isClinicalSequenomState()) {
+					sampleVolumeCol.visible = false;
+					concentrationCol.visible = true;
+					sampleTypeCol.visible = true;
+					organismCol.visible = false;
+					preppedByLabCol.visible = false;
+					otherSamplePrepMethodCol.visible = false;
+					chipTypeCol.visible = false;
+					concentrationUnitCol.visible = false;
+					plateNameCol.visible = (this.selectedExperiment.@containerType == "PLATE");
+					wellNameCol.visible = (this.selectedExperiment.@containerType == "PLATE");
+					isControlCol.visible = false;
+					this.qc260Col.visible = false;
+					this.qc260280Col.visible = true;
+					this.qcConcCol.visible = false;
+					this.qcRINCol.visible = false;
+					this.qcStatusCol.visible = false;
+					this.descriptionCol.visible = false;
+					this.sampleNameColumn.visible = false;
+
+				} else if (isIsolationState()) {
+					sampleVolumeCol.visible = false;
+					concentrationCol.visible = true;
+					sampleTypeCol.visible = false;
+					organismCol.visible = false;
+					preppedByLabCol.visible = false;
+					otherSamplePrepMethodCol.visible = false;
+					chipTypeCol.visible = false;
+					concentrationUnitCol.visible = false;
+					plateNameCol.visible = false;
+					wellNameCol.visible = false;
+					isControlCol.visible = false;
+					this.qc260Col.visible = false;
+					this.qc260280Col.visible = true;
+					this.qcConcCol.visible = false;
+					this.qcRINCol.visible = false;
+					this.qcStatusCol.visible = false;
+					this.descriptionCol.visible = false;
+					this.sampleSourceCol.visible = true;
+
+					//this.concentrationCol.headerText = 'NanoDrop Conc.';
+				} else if (isIonTorrentState()) {
+					sampleVolumeCol.visible = false;
+					concentrationCol.visible = true;
+					sampleTypeCol.visible = true;
+					organismCol.visible = true;
+					preppedByLabCol.visible = false;
+					otherSamplePrepMethodCol.visible = true;
+					chipTypeCol.visible = false;
+					concentrationUnitCol.visible = false;
+					plateNameCol.visible = false;
+					wellNameCol.visible = false;
+					isControlCol.visible = false;
+					this.qc260Col.visible = true;
+					this.qc260280Col.visible = false;
+					this.qcConcCol.visible = true;
+					this.qcRINCol.visible = true;
+					this.qcStatusCol.visible = false;
+					this.descriptionCol.visible = false;
+					this.sampleSourceCol.visible = false;
+					applicationCol.visible = true;
+
+					//this.concentrationCol.headerText = 'Conc. (ng/ul)';
+
+				} else if (isGenericState()) {
+					sampleVolumeCol.visible = false;
+					concentrationCol.visible = false;
+					sampleTypeCol.visible = true;
+					organismCol.visible = true;
+					preppedByLabCol.visible = false;
+					otherSamplePrepMethodCol.visible = false;
+					chipTypeCol.visible = false;
+					concentrationUnitCol.visible = false;
 					plateNameCol.visible = false;
 					wellNameCol.visible = false;
 					isControlCol.visible = false;
@@ -1165,657 +1345,409 @@
 					this.qcConcCol.visible = false;
 					this.qcRINCol.visible = false;
 					this.qcStatusCol.visible = false;
-
-				} else {
-
-					descriptionCol.visible = true;
-
-					if (currentState == 'SolexaState') {
+					this.descriptionCol.visible = false;
+					this.sampleSourceCol.visible = false;
+					applicationCol.visible = true;
+					if (this.selectedExperiment.@codeRequestCategory == 'DDPCR') {
 						concentrationCol.visible = true;
-						sampleVolumeCol.visible = true;
-						sampleTypeCol.visible = true;
-						organismCol.visible = true;
-						preppedByLabCol.visible = true;
 						otherSamplePrepMethodCol.visible = true;
-						chipTypeCol.visible = false;
-						concentrationUnitCol.visible = false;
-						plateNameCol.visible = false;
-						wellNameCol.visible = false;
-						isControlCol.visible = false;
-						this.qc260Col.visible = false;
-						this.qc260280Col.visible = false;
-						this.qcConcCol.visible = true;
-						this.qcRINCol.visible = true;
-						this.qcStatusCol.visible = true;
-						descriptionCol.visible = false;
-
-					} else if (currentState == 'QCState' || currentState == 'ExternalQCState') {
-						sampleVolumeCol.visible = false;
-						concentrationCol.visible = false;
-						sampleTypeCol.visible = false;
-						organismCol.visible = false;
-						preppedByLabCol.visible = false;
-						otherSamplePrepMethodCol.visible = true;
-						var application:Object = parentApplication.dictionaryManager.getEntry('hci.gnomex.model.Application', this.selectedExperiment.@codeApplication);
-						chipTypeCol.visible = (application != null && application.@hasChipTypes == 'Y' ? true : false);
-						concentrationUnitCol.visible = true;
-						plateNameCol.visible = false;
-						wellNameCol.visible = false;
-						isControlCol.visible = false;
-						this.qc260Col.visible = true;
-						this.qc260280Col.visible = false;
-						this.qcConcCol.visible = true;
-						this.qcRINCol.visible = true;
-						this.qcStatusCol.visible = currentState == 'QCState';
-					} else if (isCapSeqState()) {
-						sampleVolumeCol.visible = false;
-						concentrationCol.visible = false;
-						sampleTypeCol.visible = true;
-						organismCol.visible = false;
-						preppedByLabCol.visible = false;
-						otherSamplePrepMethodCol.visible = false;
-						chipTypeCol.visible = false
-						concentrationUnitCol.visible = false;
-						plateNameCol.visible = (this.selectedExperiment.@containerType == "PLATE" ? true : false);
-						wellNameCol.visible = (this.selectedExperiment.@containerType == "PLATE" ? true : false);
-						isControlCol.visible = (this.selectedExperiment.@containerType == "PLATE" ? true : false);
-						this.qc260Col.visible = false;
-						this.qc260280Col.visible = false;
-						this.qcConcCol.visible = false;
-						this.qcRINCol.visible = false;
-						this.qcStatusCol.visible = false;
-						reactionPlateCol.visible = true;
-						redoFlagCol.visible = true;
-						this.descriptionCol.visible = false;
-
-					} else if (isMitSeqState()) {
-						sampleVolumeCol.visible = false;
-						concentrationCol.visible = false;
-						sampleTypeCol.visible = false;
-						organismCol.visible = false;
-						preppedByLabCol.visible = false;
-						otherSamplePrepMethodCol.visible = false;
-						chipTypeCol.visible = false
-						concentrationUnitCol.visible = false;
-						plateNameCol.visible = false;
-						wellNameCol.visible = true;
-						isControlCol.visible = false;
-						this.qc260Col.visible = false;
-						this.qc260280Col.visible = false;
-						this.qcConcCol.visible = false;
-						this.qcRINCol.visible = false;
-						this.qcStatusCol.visible = false;
-						reactionPlateCol.visible = true;
-						redoFlagCol.visible = true;
-
-					} else if (isFragAnalState()) {
-						sampleVolumeCol.visible = false;
-						concentrationCol.visible = false;
-						sampleTypeCol.visible = false;
-						organismCol.visible = false;
-						preppedByLabCol.visible = false;
-						otherSamplePrepMethodCol.visible = false;
-						chipTypeCol.visible = false
-						concentrationUnitCol.visible = false;
-						plateNameCol.visible = false;
-						wellNameCol.visible = true;
-						isControlCol.visible = false;
-						this.qc260Col.visible = false;
-						this.qc260280Col.visible = false;
-						this.qcConcCol.visible = false;
-						this.qcRINCol.visible = false;
-						this.qcStatusCol.visible = false;
-						reactionPlateCol.visible = true;
-					} else if (isCherryPickState()) {
-						sampleVolumeCol.visible = false;
-						concentrationCol.visible = false;
-						sampleTypeCol.visible = false;
-						organismCol.visible = false;
-						preppedByLabCol.visible = false;
-						otherSamplePrepMethodCol.visible = false;
-						chipTypeCol.visible = false
-						concentrationUnitCol.visible = false;
-						plateNameCol.visible = false;
-						wellNameCol.visible = false;
-						isControlCol.visible = false;
-						this.qc260Col.visible = false;
-						this.qc260280Col.visible = false;
-						this.qcConcCol.visible = false;
-						this.qcRINCol.visible = false;
-						this.qcStatusCol.visible = false;
-						this.cherryDestinationWellCol.visible = true;
-						this.cherrySourcePlateCol.visible = true;
-						this.cherrySourceWellCol.visible = true;
-						reactionPlateCol.visible = true;
-
-					} else if (isIScanState()) {
-						sampleVolumeCol.visible = false;
-						concentrationCol.visible = false;
-						sampleTypeCol.visible = false;
-						organismCol.visible = false;
-						preppedByLabCol.visible = false;
-						otherSamplePrepMethodCol.visible = false;
-						chipTypeCol.visible = false
-						concentrationUnitCol.visible = false;
-						plateNameCol.visible = false;
-						wellNameCol.visible = true;
-						isControlCol.visible = false;
-						this.qc260Col.visible = false;
-						this.qc260280Col.visible = false;
-						this.qcConcCol.visible = false;
-						this.qcRINCol.visible = false;
-						this.qcStatusCol.visible = false;
-						this.cherryDestinationWellCol.visible = false;
-						this.cherrySourcePlateCol.visible = false;
-						this.cherrySourceWellCol.visible = false;
-						reactionPlateCol.visible = false;
-						this.descriptionCol.visible = false;
-
-					} else if (isSequenomState()) {
-						sampleVolumeCol.visible = false;
-						concentrationCol.visible = true;
-						sampleTypeCol.visible = true;
-						organismCol.visible = false;
-						preppedByLabCol.visible = false;
-						otherSamplePrepMethodCol.visible = false;
-						chipTypeCol.visible = false
-						concentrationUnitCol.visible = false;
-						plateNameCol.visible = (this.selectedExperiment.@containerType == "PLATE" ? true : false);
-						wellNameCol.visible = (this.selectedExperiment.@containerType == "PLATE" ? true : false);
-						isControlCol.visible = false;
-						this.qc260Col.visible = false;
-						this.qc260280Col.visible = true;
-						this.qcConcCol.visible = false;
-						this.qcRINCol.visible = false;
-						this.qcStatusCol.visible = false;
-						this.descriptionCol.visible = false;
-
-					} else if (isClinicalSequenomState()) {
-						sampleVolumeCol.visible = false;
-						concentrationCol.visible = true;
-						sampleTypeCol.visible = true;
-						organismCol.visible = false;
-						preppedByLabCol.visible = false;
-						otherSamplePrepMethodCol.visible = false;
-						chipTypeCol.visible = false
-						concentrationUnitCol.visible = false;
-						plateNameCol.visible = (this.selectedExperiment.@containerType == "PLATE" ? true : false);
-						wellNameCol.visible = (this.selectedExperiment.@containerType == "PLATE" ? true : false);
-						isControlCol.visible = false;
-						this.qc260Col.visible = false;
-						this.qc260280Col.visible = true;
-						this.qcConcCol.visible = false;
-						this.qcRINCol.visible = false;
-						this.qcStatusCol.visible = false;
-						this.descriptionCol.visible = false;
-						this.sampleNameColumn.visible = false;
-
-					} else if (isIsolationState()) {
-						sampleVolumeCol.visible = false;
-						concentrationCol.visible = true;
-						sampleTypeCol.visible = false;
-						organismCol.visible = false;
-						preppedByLabCol.visible = false;
-						otherSamplePrepMethodCol.visible = false;
-						chipTypeCol.visible = false
-						concentrationUnitCol.visible = false;
-						plateNameCol.visible = false;
-						wellNameCol.visible = false;
-						isControlCol.visible = false;
-						this.qc260Col.visible = false;
-						this.qc260280Col.visible = true;
-						this.qcConcCol.visible = false;
-						this.qcRINCol.visible = false;
-						this.qcStatusCol.visible = false;
-						this.descriptionCol.visible = false;
-						this.sampleSourceCol.visible = true;
-
-						//this.concentrationCol.headerText = 'NanoDrop Conc.';
-					} else if (isIonTorrentState()) {
-						sampleVolumeCol.visible = false;
-						concentrationCol.visible = true;
-						sampleTypeCol.visible = true;
-						organismCol.visible = true;
-						preppedByLabCol.visible = false;
-						otherSamplePrepMethodCol.visible = true;
-						chipTypeCol.visible = false
-						concentrationUnitCol.visible = false;
-						plateNameCol.visible = false;
-						wellNameCol.visible = false;
-						isControlCol.visible = false;
-						this.qc260Col.visible = true;
-						this.qc260280Col.visible = false;
-						this.qcConcCol.visible = true;
-						this.qcRINCol.visible = true;
-						this.qcStatusCol.visible = false;
-						this.descriptionCol.visible = false;
-						this.sampleSourceCol.visible = false;
-						applicationCol.visible = true;
-
-						//this.concentrationCol.headerText = 'Conc. (ng/ul)';
-
-					}  else if (isGenericState()) {
-						sampleVolumeCol.visible = false;
-						concentrationCol.visible = false;
-						sampleTypeCol.visible = true;
-						organismCol.visible = true;
-						preppedByLabCol.visible = false;
-						otherSamplePrepMethodCol.visible = false;
-						chipTypeCol.visible = false
-						concentrationUnitCol.visible = false;
-						plateNameCol.visible = false;
-						wellNameCol.visible = false;
-						isControlCol.visible = false;
-						this.qc260Col.visible = false;
-						this.qc260280Col.visible = false;
-						this.qcConcCol.visible = false;
-						this.qcRINCol.visible = false;
-						this.qcStatusCol.visible = false;
-						this.descriptionCol.visible = false;
-						this.sampleSourceCol.visible = false;
-						applicationCol.visible = true;
-						if ( this.selectedExperiment.@codeRequestCategory == 'DDPCR' ){
-							concentrationCol.visible = true;
-							otherSamplePrepMethodCol.visible = true;
-							applicationCol.visible = false;
-						}
-					}  else {
-						sampleVolumeCol.visible = false;
-						concentrationCol.visible = true;
-						sampleTypeCol.visible = true;
-						organismCol.visible = true;
-						preppedByLabCol.visible = false;
-						otherSamplePrepMethodCol.visible = true;
-						chipTypeCol.visible = false;
-						concentrationUnitCol.visible = false;
-						plateNameCol.visible = false;
-						wellNameCol.visible = false;
-						isControlCol.visible = false;
-						this.qc260Col.visible = true;
-						this.qc260280Col.visible = false;
-						this.qcConcCol.visible = true;
-						this.qcRINCol.visible = true;
-						this.qcStatusCol.visible = true;
+						applicationCol.visible = false;
 					}
-				}
-
-				this.initializeBarcoding();
-				otherOrganismCol.visible = false;
-			}
-
-			public function showRelatedAnalysis():void {
-				parentApplication.showAnalysisForExperiment(this.selectedExperiment);
-			}
-
-			private function onDoubleClickRelatedAnalysis():void {
-				var selectedItem:Object = this.relatedAnalysisTree.selectedItem;
-				showRelatedObject(selectedItem);
-			}
-			private function onDoubleClickRelatedTopic():void {
-				var selectedItem:Object = this.relatedTopicsTree.selectedItem;
-				showRelatedObject(selectedItem);
-			}
-
-			private function showRelatedObject(selectedItem:Object):void {
-				if (selectedItem.name() == "Analysis") {
-					parentApplication.showAnalysisForNumber(selectedItem.@number);
-				} else if (selectedItem.name() == "DataTrack") {
-					parentApplication.showDataTrackForNumber(selectedItem.@number);
-				} else if (selectedItem.name() == "Topic") {
-					parentApplication.showTopicForNumber(selectedItem.@idTopic);
-				} else if (selectedItem.name() == "Request" && selectedExperiment.@idRequest != selectedItem.@idRequest) {
-					parentApplication.showExperimentById(selectedItem.@idRequest);
+				} else {
+					sampleVolumeCol.visible = false;
+					concentrationCol.visible = true;
+					sampleTypeCol.visible = true;
+					organismCol.visible = true;
+					preppedByLabCol.visible = false;
+					otherSamplePrepMethodCol.visible = true;
+					chipTypeCol.visible = false;
+					concentrationUnitCol.visible = false;
+					plateNameCol.visible = false;
+					wellNameCol.visible = false;
+					isControlCol.visible = false;
+					this.qc260Col.visible = true;
+					this.qc260280Col.visible = false;
+					this.qcConcCol.visible = true;
+					this.qcRINCol.visible = true;
+					this.qcStatusCol.visible = true;
 				}
 			}
 
-			// Get all options (include inactive)
-			public function getPropertyOptions(idProperty:String):XMLList {
-				return parentApplication.getPropertyOptions(idProperty, true);
+			this.initializeBarcoding();
+			otherOrganismCol.visible = false;
+		}
+
+		public function showRelatedAnalysis():void {
+			parentApplication.showAnalysisForExperiment(this.selectedExperiment);
+		}
+
+		private function onDoubleClickRelatedAnalysis():void {
+			var selectedItem:Object = this.relatedAnalysisTree.selectedItem;
+			showRelatedObject(selectedItem);
+		}
+
+		private function onDoubleClickRelatedTopic():void {
+			var selectedItem:Object = this.relatedTopicsTree.selectedItem;
+			showRelatedObject(selectedItem);
+		}
+
+		private function showRelatedObject(selectedItem:Object):void {
+			if (selectedItem.name() == "Analysis") {
+				parentApplication.showAnalysisForNumber(selectedItem.@number);
+			} else if (selectedItem.name() == "DataTrack") {
+				parentApplication.showDataTrackForNumber(selectedItem.@number);
+			} else if (selectedItem.name() == "Topic") {
+				parentApplication.showTopicForNumber(selectedItem.@idTopic);
+			} else if (selectedItem.name() == "Request" && selectedExperiment.@idRequest != selectedItem.@idRequest) {
+				parentApplication.showExperimentById(selectedItem.@idRequest);
+			}
+		}
+
+		// Get all options (include inactive)
+		public function getPropertyOptions(idProperty:String):XMLList {
+			return parentApplication.getPropertyOptions(idProperty, true);
+		}
+
+		private function addAssayColumns():void {
+			var columns:Array = samplesGridConfirm.columns;
+			var newColumns:Array = [];
+
+			// remove any existing assay columns
+			var colRemoved:Boolean = false;
+			for each(var remCol:AdvancedDataGridColumn in columns) {
+				if (remCol.dataField == null || remCol.dataField.substr(0, 9) != "@hasAssay") {
+					newColumns.push(remCol);
+				} else {
+					colRemoved = true;
+				}
+			}
+			if (colRemoved) {
+				samplesGridConfirm.columns = newColumns;
+				samplesGridConfirm.validateNow();
 			}
 
-			private function addAssayColumns():void {
-				var columns:Array = samplesGridConfirm.columns;
-				var newColumns:Array = new Array();
-
-				// remove any existing assay columns
-				var colRemoved:Boolean = false;
-				for each(var remCol:AdvancedDataGridColumn in columns) {
-					if (remCol.dataField == null || remCol.dataField.substr(0, 9) != "@hasAssay") {
-						newColumns.push(remCol);
-                    } else {
-                        colRemoved = true;
-                    }
-                }
-                if (colRemoved) {
-                    samplesGridConfirm.columns = newColumns;
-                    samplesGridConfirm.validateNow();
-                }
-
-                if (isFragAnalState()) {
-                    columns = samplesGridConfirm.columns;
-                    newColumns = new Array();
-                    for each(var addCol:AdvancedDataGridColumn in columns) {
-                        if (addCol.dataField == "@description") {
-                            for each (var assay:Object in assays) {
-                                var newCol:AdvancedDataGridColumn = new AdvancedDataGridColumn();
-                                newCol.dataField  = "@hasAssay" + assay.@name;
-                                newCol.headerText = assay.@name;
-                                newCol.visible    = true;
-                                newCol.width	  = 40;
-                                newColumns.push(newCol);
-                            }
-                        }
-                        newColumns.push(addCol);
-                    }
-                    samplesGridConfirm.columns = newColumns;
-                    samplesGridConfirm.validateNow();
-                }
-            }
-
-            public function addNonStandardSampleColumns():void {
-                var annotation:Object;
-                var col:AdvancedDataGridColumn;
-                var exists:Boolean = false;
-
-                addAssayColumns();
-
-                // Make all annotation columns not visible
-                for each(col in samplesGridConfirm.columns) {
-                    if (col.dataField != null && col.dataField.substr(0, 6) == "@ANNOT") {
-                        col.visible    = false;
-                    }
-                }
-
-                if (!isMitSeqState() && !isCherryPickState()) {
-                    for each(annotation in this.selectedExperiment.PropertyEntries.PropertyEntry) {
-
-                        if(annotation.@idProperty == "-1") {
-                            continue;
-                        }
-
-                        var property:XML = parentApplication.getSampleProperty(annotation.@idProperty);
-                        if ( property == null ) {
-                            continue;
-                        }
-                        var headerName:String = "";
-                        if (property.@name == "Other" && annotation.@otherLabel != "" ) {
-                            headerName = annotation.@otherLabel;
-                            annotation.@isSelected = "true";
-                        } else {
-                            headerName = annotation.@name;
-                        }
-
-                        // Note we don't specify application because that is taken care of in the back end (GetRequest).
-                        var isApplicable:Boolean = AnnotationUtility.isApplicableProperty(parentApplication.getSampleProperty(annotation.@idProperty),
-                                parentApplication.dictionaryManager.getEntry('hci.gnomex.model.RequestCategory',this.selectedExperiment.@codeRequestCategory),
-                                this.selectedExperiment.@idOrganism, this.selectedExperiment.@codeApplication);
-
-                        exists = false;
-
-                        for each(col in samplesGridConfirm.columns) {
-                            if (col.dataField == ("@ANNOT" + annotation.@idProperty)) {
-                                exists = true;
-                                col.visible    = annotation.@isSelected == "true" && isApplicable ? true : false;
-                                col.headerText = headerName;
-                                break;
-                            }
-                        }
-
-                        // We already have this column.  Just set the header and visible and move on.
-                        var newCol:AdvancedDataGridToolTipColumn = new AdvancedDataGridToolTipColumn();
-                        if (exists) {
-                            newCol = AdvancedDataGridToolTipColumn(col);
-                        } else {
-                            newCol.dataField  = "@ANNOT" + annotation.@idProperty;
-                            newCol.headerText = headerName;
-                            newCol.visible    = (annotation.@isSelected == "true" && isApplicable ? true : false);
-                            newCol.headerWordWrap = true;
-                            if (property.@description != null && property.@description.toString() != "") {
-                                newCol.headerToolTip = property.@description
-                            } else {
-                                newCol.headerToolTip = property.@name;
-                            }
-
-                            if (property.@codePropertyType == 'MOPTION') {
-                                newCol.itemRenderer =  MultiselectRenderer.create(false);
-                            } else if (property.@codePropertyType == 'URL') {
-                                newCol.itemRenderer = URLRenderer.create(false);
-                            } else if (property.@codePropertyType == 'CHECK') {
-                                // checkbox is just normal label renderer
-                            } else if (property.@codePropertyType == 'OPTION') {
-                                newCol.itemRenderer = views.renderers.DropdownLabel.create(
-                                        parentApplication.getPropertyOptions(annotation.@idProperty),
-                                        '@option',
-                                        '@idPropertyOption',
-                                        "@ANNOT" + annotation.@idProperty,
-                                        '',
-                                        false);
-                            } else{
-                                newCol.wordWrap = true;
-                            }
-                        }
-
-                        // Place the new column right after the description column
-                        var columns:Array = samplesGridConfirm.columns;
-                        var newColumns:Array = new Array();
-                        for each(var column:AdvancedDataGridColumn in columns) {
-                            if((currentState == 'SolexaState' || currentState == 'MicroarrayState' || currentState == 'QCState'
-                                    || currentState == null || isNanoStringState() || this.isSequenomState() || this.isIonTorrentState() || currentState == 'ExternalMicroarrayState'
-                                    || currentState == 'ExternalSeqState' || currentState == 'ExternalQCState') && column.dataField == "@idSampleType"){
-                                newColumns.push(newCol);
-                            }
-
-                            if (column != newCol) {
-                                newColumns.push(column);
-                            }
-                        }
-
-                        if(this.isIsolationState() || this.isIScanState() || this.isCapSeqState() || this.isFragAnalState() ){
-                            newColumns.push(newCol);
-                        }
-
-                        samplesGridConfirm.columns = newColumns;
-
-                        samplesGridConfirm.validateNow();
-                    }
-                }
-            }
-
-            private function showProtocol(idProtocol:Object, protocolClassName:String):void {
-                var params:Object = new Object();
-                params.id = idProtocol;
-                params.protocolClassName = protocolClassName;
-                getProtocol.send(params);
-            }
-
-            private function showAdapters(protocolClassName:String, fivePrime:String, threePrime:String):void {
-                var adapterWindow:AdapterWindow = AdapterWindow(PopUpManager.createPopUp(DisplayObject(this.parentDocument), AdapterWindow, false));
-                PopUpManager.centerPopUp(adapterWindow);
-                adapterWindow.title = protocolClassName;
-                adapterWindow.adapterTextArea.text = "Read 1 Adapter:\n " + threePrime + "\n\n" + "Read 2 Adapter:\n " + fivePrime;
-            }
-
-            private function onGetProtocol(event:ResultEvent): void {
-                if (getProtocol.lastResult.name() != "Protocol") {
-                    mx.controls.Alert.show(getProtocol.lastResult..ACTMESSAGE.@TEXT);
-                    return;
-                }
-                var protocolWindow:ProtocolWindow = ProtocolWindow(PopUpManager.createPopUp(DisplayObject(this.parentDocument), ProtocolWindow, false));
-                PopUpManager.centerPopUp(protocolWindow);
-                protocolWindow.init(getProtocol.lastResult);
-            }
-
-            public function getLaneTreeIcon(item:Object):Class {
-                return null;
-            }
-
-            public function refreshDownloadList():void {
-
-                if (theTab.selectedChild == filesView) {
-                    var params:Object = new Object();
-                    params.idRequest = this.selectedExperiment.@idRequest;
-                    if (parentApplication.needToLoad(params) ) {
-                        var oldId:String = parentApplication.lastGetRequestDownloadListidRequest;
-                        var newId:String = parentApplication.lastGetRequestDownloadListrequestNumber;
-                        if (oldId == null) oldId = "crap";
-                        if (newId == null) newId = "crap";
-                        params.whereami = "1" + "/" + oldId + "/" + newId;
-
-                        filesView.getRequestDownloadList.send(params);
-                    }
-
-                    filesView.browseParameters = params;
-                }
-            }
-
-            public function filterList():void{		}
-
-            protected function tabChangeHandler(event:IndexChangedEvent):void
-            {
-                refreshDownloadList();
-            }
-
-            [Bindable]
-            private var selectedFileList:XMLListCollection;
-
-            public function isControlLabelFunction(item:Object, column:AdvancedDataGridColumn):String
-            {
-                if (item is XML) {
-                    if (item.@isControl == "N") {
-                        return "";
-                    } else {
-                        return item.@isControl;
-                    }
-                } else {
-                    return "";
-                }
-            }
-
-            public function groupNameLabelFunction(item:Object, column:AdvancedDataGridColumn):String
-            {
-                if (item is XML) {
-                    return "";
-                } else {
-                    return item.groupLabel;
-                }
-            }
-
-            public function navigateToURLLink(ccNumber:String):void {
-
-                if ( ccNumber == null ) {
-                    return;
-                }
-
-                var url:String = parentApplication.getProperty(parentApplication.PROPERTY_GNOMEX_LINKAGE_BST_URL) + "#ccNumber=" + ccNumber;
-
-                navigateToURL( new URLRequest(url), '_blank' );
-            }
-
-            private function showCollaboratorWindow():void {
-                var collaboratorWindow:CollaboratorWindow = CollaboratorWindow(PopUpManager.createPopUp(parentApplication.theBody, CollaboratorWindow, true));
-                PopUpManager.centerPopUp(collaboratorWindow);
-                collaboratorWindow.init("Collaborators for Experiment " + selectedExperiment.@number,
-                        collaborators,
-                        selectedExperiment);
-
-            }
-
-            private function filterPropertyEntry(sce:Object):Boolean {
-                var keep:Boolean = false;
-
-                var property:XML = parentApplication.getSampleProperty(sce.@idProperty);
-                if(sce.@idProperty == "-1" || property == null) {
-                    return true;	// Special case for "Description" field which is not a "real" property
-                }
-                var requestCategory:Object = parentApplication.dictionaryManager.getEntry('hci.gnomex.model.RequestCategory',this.selectedExperiment.@codeRequestCategory);
-                if (AnnotationUtility.isApplicableProperty(property, requestCategory, this.selectedExperiment.@idOrganism, selectedExperiment.@codeApplication)) {
-                    if (sce.@isSelected == 'true' || property.@isActive != 'N') {
-                        keep = true;
-                    }
-                }
-
-                return keep;
-            }
-
-            private function downloadSampleSheet():void{
-                var fieldList:XMLListCollection = this.getFieldList();
-                var showUrl:URLRequest = new URLRequest('DownloadSampleSheet.gx');
-                var uv:URLVariables = new URLVariables();
-                showUrl.contentType = "application/x-www-form-urlencoded";
-                var names:String = "<NameList>"
-                for each (var node : XML in fieldList){
-                    names += node.toXMLString();
-                }
-
-                names += "</NameList>";
-                uv.names = names;
-                uv.requestXMLString = this.selectedExperiment.toXMLString();
-                showUrl.data = uv;
-                showUrl.method = URLRequestMethod.POST;
-                navigateToURL(showUrl, '_blank');
-            }
-
-            private function getFieldList():XMLListCollection {
-
-                var fieldList:XMLListCollection = new XMLListCollection();
-                // Build the contents of the columns selection list
-                var grid:CopyPasteSampleGrid = samplesGridConfirm;
-                for each(var col:AdvancedDataGridColumn in grid.columns) {
-                    if(col.visible == false || col.headerText == ""){
-                        continue;
-                    }
-                    if (col.dataField != null && col.dataField == '@codeConcentrationUnit') {
-                        continue;
-                    }
-
-                    var fieldType:String = "TEXT";
-                    if(col is AdvancedDataGridColumnWithType) {
-                        fieldType = AdvancedDataGridColumnWithType(col).propertyType;
-                    }
-
-                    var emptyNode:XML = new XML("<FieldItem " +
-                            " dataField='" + col.dataField + "' fieldText='" + col.headerText +
-                            "' fieldType='" + fieldType + "' selectedSSColumn='0'/>");
-                    fieldList.addItem(emptyNode);
-                }
-
-                return fieldList;
-            }
-
-            private function getSampleConcentrationFormatted(item:Object, column:AdvancedDataGridColumn):String {
-                numberFormatter.precision = sampleConcentrationPrecision;
-                if (item.hasOwnProperty("@concentration") && item.@concentration != '') {
-                    return numberFormatter.format(item.@concentration);
-                } else {
-                    return "";
-                }
-            }
-
-            private function getSampleVolumeFormatted(item:Object, column:AdvancedDataGridColumn):String {
-                numberFormatter.precision = sampleConcentrationPrecision;
-                if (item.hasOwnProperty("@sampleVolume") && item.@sampleVolume != '') {
-                    return numberFormatter.format(item.@sampleVolume);
-                } else {
-                    return "";
-                }
-            }
-
-            private function determineToShowProductsTab(requestCategory:Object):Boolean {
-                if (selectedExperiment != null && selectedExperiment.@isExternal != 'Y' && requestCategory != null) {
-                    if (requestCategory.@idProductType != null && requestCategory.@idProductType != '') {
-                        return true;
-                    }
-                }
-
-                return false;
-            }
-
-            private function getConcentrationHeader():void{
-                if(this.samples.length > 0){
-                    concHeader += "("+samples.getItemAt(0).@codeConcentrationUnit+")";
-                }
+			if (isFragAnalState()) {
+				columns = samplesGridConfirm.columns;
+				newColumns = [];
+				for each(var addCol:AdvancedDataGridColumn in columns) {
+					if (addCol.dataField == "@description") {
+						for each (var assay:Object in assays) {
+							var newCol:AdvancedDataGridColumn = new AdvancedDataGridColumn();
+							newCol.dataField = "@hasAssay" + assay.@name;
+							newCol.headerText = assay.@name;
+							newCol.visible = true;
+							newCol.width = 40;
+							newColumns.push(newCol);
+						}
+					}
+					newColumns.push(addCol);
+				}
+				samplesGridConfirm.columns = newColumns;
+				samplesGridConfirm.validateNow();
 			}
-			
+		}
+
+		public function addNonStandardSampleColumns():void {
+			var annotation:Object;
+			var col:AdvancedDataGridColumn;
+			var exists:Boolean = false;
+
+			addAssayColumns();
+
+			// Make all annotation columns not visible
+			for each(col in samplesGridConfirm.columns) {
+				if (col.dataField != null && col.dataField.substr(0, 6) == "@ANNOT") {
+					col.visible = false;
+				}
+			}
+
+			if (!isMitSeqState() && !isCherryPickState()) {
+				for each(annotation in this.selectedExperiment.PropertyEntries.PropertyEntry) {
+
+					if (annotation.@idProperty == "-1") {
+						continue;
+					}
+
+					var property:XML = parentApplication.getSampleProperty(annotation.@idProperty);
+					if (property == null) {
+						continue;
+					}
+					var headerName:String = "";
+					if (property.@name == "Other" && annotation.@otherLabel != "") {
+						headerName = annotation.@otherLabel;
+						annotation.@isSelected = "true";
+					} else {
+						headerName = annotation.@name;
+					}
+
+					// Note we don't specify application because that is taken care of in the back end (GetRequest).
+					var isApplicable:Boolean = AnnotationUtility.isApplicableProperty(parentApplication.getSampleProperty(annotation.@idProperty),
+							parentApplication.dictionaryManager.getEntry('hci.gnomex.model.RequestCategory', this.selectedExperiment.@codeRequestCategory),
+							this.selectedExperiment.@idOrganism, this.selectedExperiment.@codeApplication);
+
+					exists = false;
+
+					for each(col in samplesGridConfirm.columns) {
+						if (col.dataField == ("@ANNOT" + annotation.@idProperty)) {
+							exists = true;
+							col.visible = (annotation.@isSelected == "true" && isApplicable);
+							col.headerText = headerName;
+							break;
+						}
+					}
+
+					// We already have this column.  Just set the header and visible and move on.
+					var newCol:AdvancedDataGridToolTipColumn = new AdvancedDataGridToolTipColumn();
+					if (exists) {
+						newCol = AdvancedDataGridToolTipColumn(col);
+					} else {
+						newCol.dataField = "@ANNOT" + annotation.@idProperty;
+						newCol.headerText = headerName;
+						newCol.visible = (annotation.@isSelected == "true" && isApplicable);
+						newCol.headerWordWrap = true;
+						if (property.@description != null && property.@description.toString() != "") {
+							newCol.headerToolTip = property.@description
+						} else {
+							newCol.headerToolTip = property.@name;
+						}
+
+						if (property.@codePropertyType == 'MOPTION') {
+							newCol.itemRenderer = MultiselectRenderer.create(false);
+						} else if (property.@codePropertyType == 'URL') {
+							newCol.itemRenderer = URLRenderer.create(false);
+						} else if (property.@codePropertyType == 'CHECK') {
+							// checkbox is just normal label renderer
+						} else if (property.@codePropertyType == 'OPTION') {
+							newCol.itemRenderer = views.renderers.DropdownLabel.create(
+									parentApplication.getPropertyOptions(annotation.@idProperty),
+									'@option',
+									'@idPropertyOption',
+									"@ANNOT" + annotation.@idProperty,
+									'',
+									false);
+						} else {
+							newCol.wordWrap = true;
+						}
+					}
+
+					// Place the new column right after the description column
+					var columns:Array = samplesGridConfirm.columns;
+					var newColumns:Array = [];
+					for each(var column:AdvancedDataGridColumn in columns) {
+						if ((currentState == 'SolexaState' || currentState == 'MicroarrayState' || currentState == 'QCState'
+								|| currentState == null || isNanoStringState() || this.isSequenomState() || this.isIonTorrentState() || currentState == 'ExternalMicroarrayState'
+								|| currentState == 'ExternalSeqState' || currentState == 'ExternalQCState') && column.dataField == "@idSampleType") {
+							newColumns.push(newCol);
+						}
+
+						if (column != newCol) {
+							newColumns.push(column);
+						}
+					}
+
+					if (this.isIsolationState() || this.isIScanState() || this.isCapSeqState() || this.isFragAnalState()) {
+						newColumns.push(newCol);
+					}
+
+					samplesGridConfirm.columns = newColumns;
+
+					samplesGridConfirm.validateNow();
+				}
+			}
+		}
+
+		private function showProtocol(idProtocol:Object, protocolClassName:String):void {
+			var params:Object = {};
+			params.id = idProtocol;
+			params.protocolClassName = protocolClassName;
+			getProtocol.send(params);
+		}
+
+		private function showAdapters(protocolClassName:String, fivePrime:String, threePrime:String):void {
+			var adapterWindow:AdapterWindow = AdapterWindow(PopUpManager.createPopUp(DisplayObject(this.parentDocument), AdapterWindow, false));
+			PopUpManager.centerPopUp(adapterWindow);
+			adapterWindow.title = protocolClassName;
+			adapterWindow.adapterTextArea.text = "Read 1 Adapter:\n " + threePrime + "\n\n" + "Read 2 Adapter:\n " + fivePrime;
+		}
+
+		private function onGetProtocol(event:ResultEvent):void {
+			if (getProtocol.lastResult.name() != "Protocol") {
+				Alert.show(getProtocol.lastResult..ACTMESSAGE.@TEXT);
+				return;
+			}
+			var protocolWindow:ProtocolWindow = ProtocolWindow(PopUpManager.createPopUp(DisplayObject(this.parentDocument), ProtocolWindow, false));
+			PopUpManager.centerPopUp(protocolWindow);
+			protocolWindow.init(getProtocol.lastResult);
+		}
+
+		public function getLaneTreeIcon(item:Object):Class {
+			return null;
+		}
+
+		public function refreshDownloadList():void {
+
+			if (theTab.selectedChild == filesView) {
+				var params:Object = {};
+				params.idRequest = this.selectedExperiment.@idRequest;
+				if (parentApplication.needToLoad(params)) {
+					var oldId:String = parentApplication.lastGetRequestDownloadListidRequest;
+					var newId:String = parentApplication.lastGetRequestDownloadListrequestNumber;
+					if (oldId == null) oldId = "crap";
+					if (newId == null) newId = "crap";
+					params.whereami = "1" + "/" + oldId + "/" + newId;
+
+					filesView.getRequestDownloadList.send(params);
+				}
+
+				filesView.browseParameters = params;
+			}
+		}
+
+		public function filterList():void {
+		}
+
+		protected function tabChangeHandler(event:IndexChangedEvent):void {
+			refreshDownloadList();
+		}
+
+		[Bindable]
+		private var selectedFileList:XMLListCollection;
+
+		public function isControlLabelFunction(item:Object, column:AdvancedDataGridColumn):String {
+			if (item is XML) {
+				if (item.@isControl == "N") {
+					return "";
+				} else {
+					return item.@isControl;
+				}
+			} else {
+				return "";
+			}
+		}
+
+		public function groupNameLabelFunction(item:Object, column:AdvancedDataGridColumn):String {
+			if (item is XML) {
+				return "";
+			} else {
+				return item.groupLabel;
+			}
+		}
+
+		public function navigateToURLLink(ccNumber:String):void {
+
+			if (ccNumber == null) {
+				return;
+			}
+
+			var url:String = parentApplication.getProperty(parentApplication.PROPERTY_GNOMEX_LINKAGE_BST_URL) + "#ccNumber=" + ccNumber;
+
+			navigateToURL(new URLRequest(url), '_blank');
+		}
+
+		private function showCollaboratorWindow():void {
+			var collaboratorWindow:CollaboratorWindow = CollaboratorWindow(PopUpManager.createPopUp(parentApplication.theBody, CollaboratorWindow, true));
+			PopUpManager.centerPopUp(collaboratorWindow);
+			collaboratorWindow.init("Collaborators for Experiment " + selectedExperiment.@number,
+					collaborators,
+					selectedExperiment);
+
+		}
+
+		private function filterPropertyEntry(sce:Object):Boolean {
+			var keep:Boolean = false;
+
+			var property:XML = parentApplication.getSampleProperty(sce.@idProperty);
+			if (sce.@idProperty == "-1" || property == null) {
+				return true;	// Special case for "Description" field which is not a "real" property
+			}
+			var requestCategory:Object = parentApplication.dictionaryManager.getEntry('hci.gnomex.model.RequestCategory', this.selectedExperiment.@codeRequestCategory);
+			if (AnnotationUtility.isApplicableProperty(property, requestCategory, this.selectedExperiment.@idOrganism, selectedExperiment.@codeApplication)) {
+				if (sce.@isSelected == 'true' || property.@isActive != 'N') {
+					keep = true;
+				}
+			}
+
+			return keep;
+		}
+
+		private function downloadSampleSheet():void {
+			var fieldList:XMLListCollection = this.getFieldList();
+			var showUrl:URLRequest = new URLRequest('DownloadSampleSheet.gx');
+			var uv:URLVariables = new URLVariables();
+			showUrl.contentType = "application/x-www-form-urlencoded";
+			var names:String = "<NameList>";
+			for each (var node:XML in fieldList) {
+				names += node.toXMLString();
+			}
+
+			names += "</NameList>";
+			uv.names = names;
+			uv.requestXMLString = this.selectedExperiment.toXMLString();
+			showUrl.data = uv;
+			showUrl.method = URLRequestMethod.POST;
+			navigateToURL(showUrl, '_blank');
+		}
+
+		private function getFieldList():XMLListCollection {
+
+			var fieldList:XMLListCollection = new XMLListCollection();
+			// Build the contents of the columns selection list
+			var grid:CopyPasteSampleGrid = samplesGridConfirm;
+			for each(var col:AdvancedDataGridColumn in grid.columns) {
+				if (col.visible == false || col.headerText == "") {
+					continue;
+				}
+				if (col.dataField != null && col.dataField == '@codeConcentrationUnit') {
+					continue;
+				}
+
+				var fieldType:String = "TEXT";
+				if (col is AdvancedDataGridColumnWithType) {
+					fieldType = AdvancedDataGridColumnWithType(col).propertyType;
+				}
+
+				var emptyNode:XML = new XML("<FieldItem " +
+						" dataField='" + col.dataField + "' fieldText='" + col.headerText +
+						"' fieldType='" + fieldType + "' selectedSSColumn='0'/>");
+				fieldList.addItem(emptyNode);
+			}
+
+			return fieldList;
+		}
+
+		private function getSampleConcentrationFormatted(item:Object, column:AdvancedDataGridColumn):String {
+			numberFormatter.precision = sampleConcentrationPrecision;
+			if (item.hasOwnProperty("@concentration") && item.@concentration != '') {
+				return numberFormatter.format(item.@concentration);
+			} else {
+				return "";
+			}
+		}
+
+		private function getSampleVolumeFormatted(item:Object, column:AdvancedDataGridColumn):String {
+			numberFormatter.precision = sampleConcentrationPrecision;
+			if (item.hasOwnProperty("@sampleVolume") && item.@sampleVolume != '') {
+				return numberFormatter.format(item.@sampleVolume);
+			} else {
+				return "";
+			}
+		}
+
+		private function determineToShowProductsTab(requestCategory:Object):Boolean {
+			if (selectedExperiment != null && selectedExperiment.@isExternal != 'Y' && requestCategory != null) {
+				if (requestCategory.@idProductType != null && requestCategory.@idProductType != '') {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		private function getConcentrationHeader():void {
+			if (this.samples.length > 0) {
+				concHeader += "(" + samples.getItemAt(0).@codeConcentrationUnit + ")";
+			}
+		}
 		]]>
 	</mx:Script>
 	
@@ -1897,9 +1829,9 @@
 						<mx:Text  text="{this.selectedExperiment.@lastModifyDate}" width="280"/>
 					</mx:HBox>
 					<mx:HBox verticalGap="0" horizontalGap="0" id="hbox2" verticalAlign="middle" 
-							 visible="{selectedExperiment.@isExternal == 'Y' ? false : true}"
+							 visible="{selectedExperiment.@isExternal != 'Y'}"
 							 
-							 includeInLayout="{selectedExperiment.@isExternal == 'Y' ? false : true}">
+							 includeInLayout="{selectedExperiment.@isExternal != 'Y'}">
 						<mx:Label width="105" text="Completed"  styleName="formLabel" textAlign="left" id="label9"/>
 						<mx:Text    text="{this.selectedExperiment.@completedDate}" width="280"/>
 					</mx:HBox>
@@ -2237,7 +2169,7 @@
 					
 					<mx:AdvancedDataGridColumn visible="{currentState == 'SolexaState'}" headerText="Seq Lib Prep Status" width="90" dataField="@seqPrepStatus"/>
 					
-					<mx:AdvancedDataGridColumn id="ccNumberCol" visible="{this.selectedExperiment.@hasCCNumber == 'Y' ? true : false}" headerText="CC Number" width="105" dataField="@ccNumber">
+					<mx:AdvancedDataGridColumn id="ccNumberCol" visible="{this.selectedExperiment.@hasCCNumber == 'Y'}" headerText="CC Number" width="105" dataField="@ccNumber">
 						<mx:itemRenderer>
 							<mx:Component>
 								<mx:LinkButton includeInLayout="{data.hasOwnProperty('@ccNumber')}" 
@@ -2279,7 +2211,7 @@
 						<mx:AdvancedDataGridColumn headerText="Group" dataField="@labName" editable="false" width="70" wordWrap="false"/>
 						<mx:AdvancedDataGridColumn headerText="Acct" dataField="@accountName" editable="false" width="220" wordWrap="false" />
 						<mx:AdvancedDataGridColumn headerText="Period" dataField="@idBillingPeriod" editable="false" width="70"  wordWrap="false"
-												   itemRenderer="{views.renderers.DropdownLabelBillingItem.create(parentApplication.dictionaryManager.xml.Dictionary.(@className=='hci.gnomex.model.BillingPeriod').DictionaryEntry,'@display', '@value', '@idBillingPeriod')}"/>
+												   itemRenderer="{DropdownLabelBillingItem.create(parentApplication.dictionaryManager.xml.Dictionary.(@className=='hci.gnomex.model.BillingPeriod').DictionaryEntry,'@display', '@value', '@idBillingPeriod')}"/>
 
 						<mx:AdvancedDataGridColumn headerText="Description" wordWrap="true" dataField="@description" editable="false" width="200">
 							<mx:itemRenderer>
@@ -2320,7 +2252,7 @@
 							</mx:itemRenderer>
 						</mx:AdvancedDataGridColumn>
 						<mx:AdvancedDataGridColumn headerText="Status" dataField="@codeBillingStatus" editable="false" width="70" wordWrap="false"
-												   itemRenderer="{views.renderers.DropdownLabelBillingItem.create(parentApplication.dictionaryManager.xml.Dictionary.(@className=='hci.gnomex.model.BillingStatus').DictionaryEntry,'@display', '@value', '@codeBillingStatus')}"/>                 
+												   itemRenderer="{DropdownLabelBillingItem.create(parentApplication.dictionaryManager.xml.Dictionary.(@className=='hci.gnomex.model.BillingStatus').DictionaryEntry,'@display', '@value', '@codeBillingStatus')}"/>
 					</mx:columns>
 				</mx:AdvancedDataGrid>
 			</mx:VBox>
@@ -2520,10 +2452,10 @@
 							<mx:DataGridColumn visible="{showExtFieldsCheckBox.selected}" headerText="Ext Status" width="90" dataField="@extractionStatus"/>
 							
 							
-							<mx:DataGridColumn headerText="Slide" visible="{showCy3LabelingFieldsCheckBox.selected || showCy5LabelingFieldsCheckBox.selected || showHybFieldsCheckBox.selected || showExtFieldsCheckBox.selected ? false : true}"  width="320" dataField="@slideDesignName" />
-							<mx:DataGridColumn headerText="Slide Source"  visible="{showCy3LabelingFieldsCheckBox.selected || showCy5LabelingFieldsCheckBox.selected || showHybFieldsCheckBox.selected || showExtFieldsCheckBox.selected ? false : true}"   width="82"   
+							<mx:DataGridColumn headerText="Slide" visible="{!(showCy3LabelingFieldsCheckBox.selected || showCy5LabelingFieldsCheckBox.selected || showHybFieldsCheckBox.selected || showExtFieldsCheckBox.selected)}" width="320" dataField="@slideDesignName" />
+							<mx:DataGridColumn headerText="Slide Source" visible="{!(showCy3LabelingFieldsCheckBox.selected || showCy5LabelingFieldsCheckBox.selected || showHybFieldsCheckBox.selected || showExtFieldsCheckBox.selected)}" width="82"
 											   itemRenderer="{DropdownLabel.getFactory(parentApplication.dictionaryManager.xml.Dictionary.(@className=='hci.gnomex.model.SlideSource').DictionaryEntry, '@display', '@value', '@codeSlideSource')}"/>                 											
-							<mx:DataGridColumn headerText="Notes" width="105"  visible="{showCy3LabelingFieldsCheckBox.selected || showCy5LabelingFieldsCheckBox.selected || showExtFieldsCheckBox.selected ? false : true}"   dataField="@notes"/>
+							<mx:DataGridColumn headerText="Notes" width="105" visible="{!(showCy3LabelingFieldsCheckBox.selected || showCy5LabelingFieldsCheckBox.selected || showExtFieldsCheckBox.selected)}" dataField="@notes"/>
 						</mx:columns>
 					</mx:DataGrid>
 				</mx:VBox>

--- a/flex/views/experiment/ExperimentDetailView.mxml
+++ b/flex/views/experiment/ExperimentDetailView.mxml
@@ -506,12 +506,95 @@
 					libPrepCompletionBox.visible = false;
 				}
 
-				
+				placeSpecialQcColumns();
+
 				// Workflow progress
 				callLater(setWorkflowStatus);
-				
+
 			}
-			
+
+			private function getColumnIndexFromField(field:String):int {
+				for (var i:int; i < samplesGridConfirm.columns.length; i++) {
+					if (samplesGridConfirm.columns[i].dataField == field) {
+						return i;
+					}
+				}
+				return -1;
+			}
+
+			private function getColumnIndexFromFieldPassed(cols:Array, field:String):int {
+				for (var i:int; i < cols.length; i++) {
+					if (cols[i].dataField == field) {
+						return i;
+					}
+				}
+				return -1;
+			}
+
+			private function getFieldBefore(field:String):String {
+				var beforeCol:int = getColumnIndexFromField(field) - 1;
+				if (beforeCol >= 0) {
+					return samplesGridConfirm.columns[beforeCol].dataField;
+				} else {
+					return "";
+				}
+			}
+
+			private function moveColumn(moveField:String, otherField:String, before:Boolean):void {
+				var moveFromColumn:int = getColumnIndexFromField(moveField);
+				if (moveFromColumn < 0) {
+					return;   // field to move not found
+				}
+				var columnsCopy:Array = samplesGridConfirm.columns;
+				var column:AdvancedDataGridColumn = columnsCopy.removeAt(moveFromColumn);
+				var moveToColumn:int;
+				var otherColumn:int = getColumnIndexFromFieldPassed(columnsCopy, otherField);   // field may have shifted with removal
+				if (otherColumn >= 0) {
+					if (before) {
+						moveToColumn = otherColumn;
+					} else {
+						moveToColumn = otherColumn + 1;
+					}
+				} else {
+					moveToColumn = moveFromColumn;   // other field not found, put the field in its original location
+				}
+				columnsCopy.insertAt(moveToColumn, column);
+				samplesGridConfirm.columns = columnsCopy;
+				samplesGridConfirm.validateNow();
+			}
+
+			private function moveColumnBefore(moveField:String, otherField:String):void {
+				moveColumn(moveField, otherField, true);
+			}
+
+			private function moveColumnAfter(moveField:String, otherField:String):void {
+				moveColumn(moveField, otherField, false);
+			}
+
+			private function isIlluminaType():Boolean {
+				var requestCategory:Object = parentApplication.dictionaryManager.getEntry('hci.gnomex.model.RequestCategory', this.selectedExperiment.@codeRequestCategory);
+				return (requestCategory.@isIlluminaType == 'Y');
+			}
+
+			private var qcFieldsInitialized:Boolean = false;
+			private var qualCalcConcentrationWasAfter:String = "";
+			private var qualRINNumberWasAfter:String = "";
+
+			private function placeSpecialQcColumns():void {
+				if (!qcFieldsInitialized) {
+					qualCalcConcentrationWasAfter = getFieldBefore("@qualCalcConcentration");
+					qualRINNumberWasAfter = getFieldBefore("@qualRINNumber");
+					qcFieldsInitialized = true;
+				}
+				if (isIlluminaType()) {
+					moveColumnBefore("@qualCalcConcentration", "@idSeqLibProtocol");
+					moveColumnBefore("@qualRINNumber", "@idSeqLibProtocol");
+				} else {
+					moveColumnAfter("@qualRINNumber", qualRINNumberWasAfter);
+					moveColumnAfter("@qualCalcConcentration", qualCalcConcentrationWasAfter);
+				}
+			}
+
 			private function shouldShowMMBox():Boolean {
 				if ( libDesignAndInsertBox.visible ){
 					return true;

--- a/flex/views/experiment/ExperimentDetailView.mxml
+++ b/flex/views/experiment/ExperimentDetailView.mxml
@@ -506,99 +506,94 @@
 					libPrepCompletionBox.visible = false;
 				}
 
-				placeSpecialQcColumns();
+				placeSpecialQualColumns();
 
 				// Workflow progress
 				callLater(setWorkflowStatus);
 
 			}
 
-			private function getColumnIndexFromField(field:String):int {
-				for (var i:int; i < samplesGridConfirm.columns.length; i++) {
-					if (samplesGridConfirm.columns[i].dataField == field) {
-						return i;
-					}
-				}
-				return -1;
-			}
+			private var qualFieldsInitialized:Boolean = false;
+			private var qualCalcConcentrationWasBefore:String;
+			private var qualRINNumberWasBefore:String;
 
-			private function getColumnIndexFromFieldPassed(cols:Array, field:String):int {
-				for (var i:int; i < cols.length; i++) {
-					if (cols[i].dataField == field) {
-						return i;
-					}
+			/**
+			 *  Move the "QC Concentration" and "QC RIN" columns before "Seq Lib Protocol" for High Throughput Genomics
+			 *  Otherwise return these columns to their original positions (tracked by qualXxxxxWasBefore fields)
+			 */
+			private function placeSpecialQualColumns():void {
+				if (!qualFieldsInitialized) {
+					qualCalcConcentrationWasBefore = getFieldAfter("@qualCalcConcentration");
+					qualRINNumberWasBefore = getFieldAfter("@qualRINNumber");
+					qualFieldsInitialized = true;
 				}
-				return -1;
-			}
-
-			private function getFieldBefore(field:String):String {
-				var beforeCol:int = getColumnIndexFromField(field) - 1;
-				if (beforeCol >= 0) {
-					return samplesGridConfirm.columns[beforeCol].dataField;
+				if (isHighThroughputGenomics()) {
+					moveColumnBefore("@qualCalcConcentration", "@idSeqLibProtocol");
+					moveColumnBefore("@qualRINNumber", "@idSeqLibProtocol");
 				} else {
-					return "";
+					moveColumnBefore("@qualRINNumber", qualRINNumberWasBefore);
+					moveColumnBefore("@qualCalcConcentration", qualCalcConcentrationWasBefore);
 				}
 			}
 
-			private function moveColumn(moveField:String, otherField:String, before:Boolean):void {
+			private function isHighThroughputGenomics():Boolean {
+				return (this.selectedExperiment.@idCoreFacility == parentApplication.idCoreFacilityHTG);
+			}
+
+			private const MISSING_INDEX:int = -1;
+			private const MISSING_FIELD:String = "MISSING_FIELD";
+			private const LAST_FIELD:String = "LAST_FIELD";
+
+			private function getFieldAfter(field:String):String {
+				var column:int = getColumnIndexFromField(field);
+				if (column == MISSING_INDEX) {
+					return MISSING_FIELD;
+				}
+				if (column == samplesGridConfirm.columns.length - 1) {
+					return LAST_FIELD;
+				}
+				return samplesGridConfirm.columns[column + 1].dataField;
+			}
+
+			private function moveColumnBefore(moveField:String, otherField:String):void {
 				var moveFromColumn:int = getColumnIndexFromField(moveField);
-				if (moveFromColumn < 0) {
-					return;   // field to move not found
+				if (moveFromColumn == MISSING_INDEX) {
+					return;
 				}
 				var columnsCopy:Array = samplesGridConfirm.columns;
 				var column:AdvancedDataGridColumn = columnsCopy.removeAt(moveFromColumn);
 				var moveToColumn:int;
-				var otherColumn:int = getColumnIndexFromFieldPassed(columnsCopy, otherField);   // field may have shifted with removal
-				if (otherColumn >= 0) {
-					if (before) {
-						moveToColumn = otherColumn;
-					} else {
-						moveToColumn = otherColumn + 1;
-					}
+				var otherColumn:int = getColumnIndexFromFieldInArray(columnsCopy, otherField);
+				if (otherColumn != MISSING_INDEX) {
+					moveToColumn = otherColumn;
 				} else {
-					moveToColumn = moveFromColumn;   // other field not found, put the field in its original location
+					moveToColumn = moveFromColumn;
 				}
 				columnsCopy.insertAt(moveToColumn, column);
 				samplesGridConfirm.columns = columnsCopy;
 				samplesGridConfirm.validateNow();
 			}
 
-			private function moveColumnBefore(moveField:String, otherField:String):void {
-				moveColumn(moveField, otherField, true);
+			private function getColumnIndexFromField(field:String):int {
+				return getColumnIndexFromFieldInArray(samplesGridConfirm.columns, field);
 			}
 
-			private function moveColumnAfter(moveField:String, otherField:String):void {
-				moveColumn(moveField, otherField, false);
-			}
-
-			private function isIlluminaType():Boolean {
-				var requestCategory:Object = parentApplication.dictionaryManager.getEntry('hci.gnomex.model.RequestCategory', this.selectedExperiment.@codeRequestCategory);
-				return (requestCategory.@isIlluminaType == 'Y');
-			}
-
-			private var qcFieldsInitialized:Boolean = false;
-			private var qualCalcConcentrationWasAfter:String = "";
-			private var qualRINNumberWasAfter:String = "";
-
-			private function placeSpecialQcColumns():void {
-				if (!qcFieldsInitialized) {
-					qualCalcConcentrationWasAfter = getFieldBefore("@qualCalcConcentration");
-					qualRINNumberWasAfter = getFieldBefore("@qualRINNumber");
-					qcFieldsInitialized = true;
+			private function getColumnIndexFromFieldInArray(cols:Array, field:String):int {
+				if (field == LAST_FIELD) {
+					return cols.length;
 				}
-				if (isIlluminaType()) {
-					moveColumnBefore("@qualCalcConcentration", "@idSeqLibProtocol");
-					moveColumnBefore("@qualRINNumber", "@idSeqLibProtocol");
-				} else {
-					moveColumnAfter("@qualRINNumber", qualRINNumberWasAfter);
-					moveColumnAfter("@qualCalcConcentration", qualCalcConcentrationWasAfter);
+				for (var i:int; i < cols.length; i++) {
+					if (cols[i].dataField == field) {
+						return i;
+					}
 				}
+				return MISSING_INDEX;
 			}
 
 			private function shouldShowMMBox():Boolean {
 				if ( libDesignAndInsertBox.visible ){
 					return true;
-				} 
+				}
 				if ( this.selectedExperiment.@codeIsolationPrepType != null && this.selectedExperiment.@codeIsolationPrepType!='' ) {
 					return true;
 				}
@@ -607,7 +602,7 @@
 				}
 				return false;
 			}
-			
+
 			private function setWorkflowStatus():void {
 				// Reset the progress bar labels
 				for each(var stepLabelElement:Object in this.stepLabel) {
@@ -627,7 +622,7 @@
 				workflowProgressBox.visible = x > 0 ? true : false;
 				workflowProgressBox.includeInLayout = x > 0 ? true : false;
 			}
-			
+
 			public function initializeBarcoding():void {
 				var showSampleMultiplexGroup:Boolean = false;
 				var showSampleBarcode:Boolean = false;
@@ -655,9 +650,9 @@
 						showSampleCustomBarcodeB = true;
 					}
 				}
-				
+
 				if (showPlates) {
-					
+
 					this.samplesGridConfirm.dataProvider = null;
 					sampleGroupingCollection = new GroupingCollection();
 					sampleGroupingCollection.source = this.samples;
@@ -667,20 +662,20 @@
 					groupCapSeq.fields = [gfCapSeq];
 					gfCapSeq.compareFunction = plateSampleCompareFunction;
 					sampleGroupingCollection.grouping  = groupCapSeq;
-					sampleGroupingCollection.refresh(); 
+					sampleGroupingCollection.refresh();
 					this.samplesGridConfirm.dataProvider = sampleGroupingCollection;
-					
+
 					this.samplesGridConfirm.dragMoveEnabled = false;
 					this.samplesGridConfirm.dropEnabled = false;
 					this.samplesGridConfirm.dragEnabled = false;
-					
-					
+
+
 					this.switchFirstSampleGridColumns(this.plateNameCol, this.multiplexGroupNumberColumn);
 					this.plateNameCol.visible = true;
 					this.multiplexGroupNumberColumn.visible = false;
-					
+
 				} else if (showSampleMultiplexGroup) {
-					
+
 					this.samplesGridConfirm.dataProvider = null;
 					sampleGroupingCollection = new GroupingCollection();
 					sampleGroupingCollection.source = this.samples;
@@ -692,35 +687,35 @@
 					sampleGroupingCollection.grouping  = group;
 					sampleGroupingCollection.refresh();
 					this.samplesGridConfirm.dataProvider = sampleGroupingCollection;
-					
+
 					this.multiplexGroupNumberColumn.visible = true;
 					switchFirstSampleGridColumns(this.multiplexGroupNumberColumn, this.plateNameCol);
 					this.plateNameCol.visible = false;
-					
+
 				} else {
-					
+
 					sampleGroupingCollection = null;
 					this.samplesGridConfirm.dataProvider = this.samples;
-					
+
 					this.multiplexGroupNumberColumn.visible = false;
-					
+
 				}
-				
+
 				this.barcodeCol.visible = showSampleBarcode;
 				this.customBarcodeCol.visible = showSampleCustomBarcode;
 				this.customBarcodeColB.visible = showSampleCustomBarcodeB;
 				this.barcodeColB.visible = showSampleBarcodeB;
-				
+
 				if (currentState == "SolexaState") {
 					this.laneBarcodeCol.visible = showSampleBarcode;
 					this.laneBarcodeColB.visible = showSampleBarcode;
 					this.laneCustomBarcodeCol.visible = showSampleCustomBarcode;
 					this.laneCustomBarcodeColB.visible = showSampleCustomBarcode;
 				}
-				
+
 				this.samplesGridConfirm.validateNow();
 			}
-			
+
 			private function switchFirstSampleGridColumns (col1:AdvancedDataGridColumn, col2:AdvancedDataGridColumn):void {
 				var columns:Array = [];
 				columns[0] = col1;
@@ -730,7 +725,7 @@
 				}
 				this.samplesGridConfirm.columns = columns;
 			}
-			
+
 			private function sampleCompareFunction(a:XML, b:XML):int
 			{
 				var aPersistFlag:Number = 0;
@@ -741,7 +736,7 @@
 				} else {
 					aPosition = a.@idSample;
 				}
-				
+
 				var bPersistFlag:Number = 0;
 				var bPosition:Number = 0;
 				if (b.@idSample.toString().indexOf("Sample") > -1) {
@@ -750,14 +745,14 @@
 				} else {
 					bPosition = b.@idSample;
 				}
-				
+
 				if (aPersistFlag == bPersistFlag) {
-					return ObjectUtil.numericCompare(aPosition, bPosition);				
+					return ObjectUtil.numericCompare(aPosition, bPosition);
 				} else {
 					return ObjectUtil.numericCompare(aPersistFlag, bPersistFlag);
 				}
-			}		
-			
+			}
+
 			private function plateSampleCompareFunction(a:XML, b:XML):int
 			{
 				if (a.hasOwnProperty("@plateName") && a.hasOwnProperty("@wellName") && b.hasOwnProperty("@plateName") && b.hasOwnProperty("@wellName")) {
@@ -780,7 +775,7 @@
 					} else {
 						aPosition = a.@idSample;
 					}
-					
+
 					var bPersistFlag:Number = 0;
 					var bPosition:Number = 0;
 					if (b.@idSample.toString().indexOf("Sample") > -1) {
@@ -789,15 +784,15 @@
 					} else {
 						bPosition = b.@idSample;
 					}
-					
+
 					if (aPersistFlag == bPersistFlag) {
-						return ObjectUtil.numericCompare(aPosition, bPosition);				
+						return ObjectUtil.numericCompare(aPosition, bPosition);
 					} else {
 						return ObjectUtil.numericCompare(aPersistFlag, bPersistFlag);
 					}
 				}
 			}
-			
+
 			private function showCy3LabelCols(isVisible:Boolean):void {
 				labelCol1.visible = isVisible;
 				labelCol2.visible = isVisible;
@@ -805,7 +800,7 @@
 				labelCol4.visible = isVisible;
 				labelCol5.visible = isVisible;
 			}
-			
+
 			private function showCy5LabelCols(isVisible:Boolean):void {
 				labelCol6.visible = isVisible;
 				labelCol7.visible = isVisible;
@@ -813,7 +808,7 @@
 				labelCol9.visible = isVisible;
 				labelCol10.visible = isVisible;
 			}
-			
+
 			private function getChannel1SampleName(item:Object, col:int):String {
 				var de:XMLList = item.labeledSampleChannel1.LabeledSample.sample.Sample;
 				if (de.length() == 1) {
@@ -850,8 +845,8 @@
 			{
 				var x:int = hybsGridConfirm.dataProvider.getItemIndex(item) + 1;
 				return String(x);
-			} 
-			
+			}
+
 			private function getRequestCategoryVariables():void {
 				var requestCategory:Object = parentApplication.dictionaryManager.getEntry('hci.gnomex.model.RequestCategory', this.selectedExperiment.@codeRequestCategory);
 				if (requestCategory is XMLList) {
@@ -862,7 +857,7 @@
 						isClinicalResearch = 'N'
 					}
 				} else {
-					requestCategoryName = requestCategory.@display.toString();		
+					requestCategoryName = requestCategory.@display.toString();
 					if (requestCategory.@isClinicalResearch != null) {
 						isClinicalResearch = requestCategory.@isClinicalResearch.toString();
 					} else {
@@ -870,7 +865,7 @@
 					}
 				}
 			}
-			
+
 			private function getExperimentCategoryName():void {
 				experimentCategoryName = "";
 				if (this.selectedExperiment.protocols.Protocol.length() <= 0 || !this.headerBox.visible) {
@@ -885,7 +880,7 @@
 					}
 				}
 			}
-			
+
 			private function getSeqLibTreatments():void {
 				seqLibTreatments = "";
 				for each(var item:Object in this.selectedExperiment.seqLibTreatments.SeqLibTreatment) {
@@ -899,52 +894,52 @@
 				if (selectedExperiment.hasOwnProperty("@codeVisibility")) {
 					var visibility:Object = parentApplication.dictionaryManager.getEntry('hci.gnomex.model.Visibility', this.selectedExperiment.@codeVisibility);
 					if (visibility is XMLList) {
-						visibilityName = visibility[0].@display.toString();			
+						visibilityName = visibility[0].@display.toString();
 					} else {
 						visibilityName = visibility.@display.toString();
 					}
 				}
 			}
-			
+
 			private function getInstitutionName():void {
 				if (selectedExperiment.hasOwnProperty("@idInstitution")) {
 					var institution:Object = parentApplication.dictionaryManager.getEntry('hci.gnomex.model.Institution', this.selectedExperiment.@idInstitution);
 					if (institution is XMLList) {
-						institutionName = institution[0].@display.toString();			
+						institutionName = institution[0].@display.toString();
 					} else {
 						institutionName = institution.@display.toString();
 					}
 				}
 			}
-			
+
 			public function showDownloads():void {
 				this.theTab.selectedChild = this.filesView;
 				downloadExpandedFilesButtonView.visible = true;
 				downloadExpandedFilesButtonView.includeInLayout = true;
 			}
-			
+
 			public function promptToDeleteExperiment():void {
 				var warningMessage:String = "Delete experiment " + this.selectedExperiment.@number + "?";
-				
+
 				var billingItems:XMLList = this.selectedExperiment.billingItems.BillingItem;
 				if ( billingItems.length() > 0) {
 					warningMessage += "\n\nWARNING: This will also delete " + billingItems.length() + " billing item(s) associated with this experiment.\n\n";
 				}
-				
+
 				var statusToUseProducts:String = parentApplication.getRequestCategoryProperty(selectedExperiment.@idCoreFacility, selectedExperiment.@codeRequestCategory, parentApplication.PROPERTY_STATUS_TO_USE_PRODUCTS);
 				if (statusToUseProducts != null && statusToUseProducts != "" && selectedExperiment.hasOwnProperty("@codeRequestStatus") && selectedExperiment.@codeRequestStatus != "") {
 					var comp:RequestStatusComparator = new RequestStatusComparator();
 					if (comp.compare(selectedExperiment.@codeRequestStatus, statusToUseProducts) >= 0) {
 						warningMessage += "\n\nWARNING: This experiment may have used products. If the products were not actually consumed, please revert the status of the experiment to an earlier status or manually return the products to the lab before deleting.\n\n";
 					}
-				} 
-				
-				Alert.show(warningMessage, 
-					"Confirm", 
-					(Alert.YES | Alert.NO), this, 
-					onPromptToDeleteExperiment);
+				}
+
+				Alert.show(warningMessage,
+						"Confirm",
+						(Alert.YES | Alert.NO), this,
+						onPromptToDeleteExperiment);
 			}
-			
+
 			private function onPromptToDeleteExperiment(event:CloseEvent):void {
 				if (event.detail==Alert.YES) {
 					deleteExperiment();
@@ -953,7 +948,7 @@
 			private function deleteExperiment():void {
 				parentDocument.parentDocument.deleteExperiment();
 			}
-			
+
 			public function promptToSubmitExperiment():void {
 				if(this.productsView.enabled){
 					var error:String = this.productsView.getErrors("submit");
@@ -962,12 +957,12 @@
 						return;
 					}
 				}
-				Alert.show("Submit experiment " + this.selectedExperiment.@number + "?  After submission only facility personnel will be able to make changes.", 
-					"Confirm", 
-					(Alert.YES | Alert.NO), this, 
-					onPromptToSubmitExperiment);
+				Alert.show("Submit experiment " + this.selectedExperiment.@number + "?  After submission only facility personnel will be able to make changes.",
+						"Confirm",
+						(Alert.YES | Alert.NO), this,
+						onPromptToSubmitExperiment);
 			}
-			
+
 			private function onPromptToSubmitExperiment(event:CloseEvent):void {
 				if (event.detail==Alert.YES) {
 					submitExperiment();
@@ -976,81 +971,81 @@
 			private function submitExperiment():void {
 				parentDocument.parentDocument.submitExperiment();
 			}
-			
+
 			public function promptToArchiveExperiment():void{
-				Alert.show("Archive experiment " + this.selectedExperiment.@number + "?  Archiving an experiment will delete all files on disk associated with this experiment and it will no longer appear in browse experiment lists.  However, GNomEx will retain a record of the experiment/sample details if you wish to restore them at a later date.", 
-					"Confirm", 
-					(Alert.YES | Alert.NO), this, 
-					onPromptToArchiveExperiment);
-				
+				Alert.show("Archive experiment " + this.selectedExperiment.@number + "?  Archiving an experiment will delete all files on disk associated with this experiment and it will no longer appear in browse experiment lists.  However, GNomEx will retain a record of the experiment/sample details if you wish to restore them at a later date.",
+						"Confirm",
+						(Alert.YES | Alert.NO), this,
+						onPromptToArchiveExperiment);
+
 			}
-			
+
 			private function onPromptToArchiveExperiment(event:CloseEvent):void{
 				if (event.detail==Alert.YES) {
 					parentDocument.parentDocument.archiveExperiment();
 				}
 			}
-			
+
 			public function showPrintableRequestForm():void {
 				var url:URLRequest = new URLRequest('ShowRequestForm.gx?idRequest=' + this.selectedExperiment.@idRequest);
-				navigateToURL(url, '_blank');			
+				navigateToURL(url, '_blank');
 			}
-			
+
 			public function checkForFileView():void {
 				if(theTab.contains(this.filesView)) {
-					theTab.selectedChild = filesView;	
+					theTab.selectedChild = filesView;
 					callLater(filesView.showDownloadWindow);
 				}
-			}	
-			
+			}
+
 			public function showEditExperimentWindow():void {
 				parentDocument.parentDocument.experimentEditView.instantiateTabs(this.selectedExperiment.@codeRequestCategory, true, false);
 				parentDocument.parentDocument.experimentEditView.coreFacility = parentApplication.dictionaryManager.getEntry('hci.gnomex.model.CoreFacility', this.selectedExperiment.@idCoreFacility);
-				
+
 				parentDocument.parentDocument.experimentEditView.request = this.selectedExperiment;
 				parentDocument.parentDocument.experimentEditView.coreFacility = parentApplication.dictionaryManager.getEntry('hci.gnomex.model.CoreFacility', this.selectedExperiment.@idCoreFacility);
 				parentDocument.parentDocument.experimentEditView.samplesView.setShowCCNumber(this.selectedExperiment.@hasCCNumber == 'Y');
 				parentDocument.parentDocument.experimentEditView.selectedAssaysCollection = this.assays;
 				parentDocument.parentDocument.experimentEditView.saveDescription = GNomExStringUtil.cleanRichTextHTML(this.overallDescript.htmlText);
-				
+
 				parentDocument.parentDocument.experimentViews.selectedChild = parentDocument.parentDocument.experimentEditView;
 				if (parentDocument.parentDocument.experimentEditView.theTab.contains(parentDocument.parentDocument.experimentEditView.annotationView)) {
 					parentDocument.parentDocument.experimentEditView.annotationView.onPropertyRefreshed(null);
 					parentDocument.parentDocument.experimentEditView.annotationView.checkSecurity();
-				} 
-				
+				}
+
 				if (this.isCherryPickState()) {
 					var numDestinationWells:int = Number(this.selectedExperiment.@numDestinationWells.toString());
 					parentDocument.parentDocument.experimentEditView.cherryPlateList = this.selectedExperiment.cherryPlateList.Plate;
 					parentDocument.parentDocument.experimentEditView.samplesView.prepareCherryPickingSamplesForEdit(numDestinationWells);
 				}
-				
+
 				if (this.isIScanState() || (this.isSequenomState() && this.selectedExperiment.@containerType == "PLATE") ) {
 					parentDocument.parentDocument.experimentEditView.numIScanPlates = countPlates();
 				}
-				
+
 				var editTitle:String = (this.selectedExperiment.@isExternal == 'Y' ? 'Edit External Experiment ' :  'Edit Experiment ') + this.selectedExperiment.@number;
-				
+
 				parentDocument.parentDocument.experimentEditView.removeDataListeners();
 				parentDocument.parentDocument.experimentEditView.initializeData();
 
 				// ********************************************************************************
 				parentApplication.lastGetRequestDownloadListidRequest = "";
 				parentApplication.lastGetRequestDownloadListrequestNumber = "";
-				
+
 				parentDocument.parentDocument.experimentEditView.setupEditForm(this.selectedExperiment);
 				parentDocument.parentDocument.experimentEditView.titleLabel.text = editTitle;
-				
+
 				if (parentDocument.parentDocument.experimentEditView.samplesView.hasPlates() && !parentDocument.parentDocument.experimentEditView.isIScanState()
-					&& !parentDocument.parentDocument.experimentEditView.isSequenomState() ) {
+						&& !parentDocument.parentDocument.experimentEditView.isSequenomState() ) {
 					parentDocument.parentDocument.experimentEditView.numCapSeqPlates = countPlates();
 				}
-				
+
 				chooseEditTabs();
 				callLater(parentDocument.parentDocument.experimentEditView.setupDataListeners);
-				
+
 			}
-			
+
 			private function chooseEditTabs():void {
 				chooseEditTab(infoTab, parentDocument.parentDocument.experimentEditView.infoTab);
 				chooseEditTab(notesTab, parentDocument.parentDocument.experimentEditView.notesView);
@@ -1059,13 +1054,13 @@
 				chooseEditTab(bioinformaticsTab, parentDocument.parentDocument.experimentEditView.bioinformaticsView);
 				chooseEditTab(filesView, parentDocument.parentDocument.experimentEditView.downloadView);
 			}
-			
+
 			private function chooseEditTab(selectedTab:Object, parentTab:Container):void {
 				if (theTab.selectedChild == selectedTab && parentDocument.parentDocument.experimentEditView.theTab.contains(parentTab)) {
 					parentDocument.parentDocument.experimentEditView.defaultTab = parentTab;
 				}
 			}
-			
+
 			private function countPlates():int {
 				var prevPlate:String = "xxxx";
 				var numPlates:int = 0;
@@ -1075,24 +1070,24 @@
 					}
 					prevPlate = s.@plateName;
 				}
-				
+
 				return numPlates;
 			}
-			
+
 			public function refreshSavedExperiment(idRequest:Object):void {
 				parentDocument.parentDocument.selectedIdRequest = idRequest;
 				var parms:Object = new Object();
 				parms.idRequest = parentDocument.parentDocument.selectedIdRequest;
 				parentDocument.parentDocument.getRequest.send(parms);
-				
+
 			}
-			
+
 			public function getLanesGridRowNumber(item:Object,col:int):String
 			{
 				var x:int = this.lanesConfirmGrid.dataProvider.getItemIndex(item) + 1;
-				return String(x);     		
+				return String(x);
 			}
-			
+
 			private function showHideColumns():void {
 				descriptionCol.visible = (this.selectedExperiment.@hasSampleDescription=="Y");
 				this.cherryDestinationWellCol.visible = false;
@@ -1104,12 +1099,12 @@
 				redoFlagCol.visible = false;
 				this.sampleNameColumn.visible = true;
 				qubitConcentrationCol.visible = (this.selectedExperiment.@includeQubitConcentration=="Y");
-				
+
 				this.getConcentrationHeader();
 				// can't do this in state stuff because of external stuff below.
 				this.noteToCoreFacilityBox.visible = true;
 				this.noteToCoreFacilityBox.includeInLayout = true;
-				
+
 				// hide bio and core notes for external experiments unless populated.
 				if (this.selectedExperiment.@isExternal == "Y") {
 					if (this.noteToCoreFacilityBox.visible) {
@@ -1119,7 +1114,7 @@
 						}
 					}
 				}
-				
+
 				// Make description bigger if possible
 				if (!this.noteToCoreFacilityBox.visible) {
 					this.bioAndCoreNoteVBox.visible = false;
@@ -1128,15 +1123,15 @@
 					this.bioAndCoreNoteVBox.visible = true;
 					this.bioAndCoreNoteVBox.includeInLayout = true;
 				}
-				
+
 				if (currentState == 'ExternalSeqState') {
 					sampleTypeCol.visible = true;
 					organismCol.visible = false;
 					sampleVolumeCol.visible = false;
-					
+
 					this.otherOrganismCol.visible = false;
 					this.otherSamplePrepMethodCol.visible = false;
-					concentrationCol.visible = false; 
+					concentrationCol.visible = false;
 					preppedByLabCol.visible = false;
 					chipTypeCol.visible = false;
 					concentrationUnitCol.visible = false;
@@ -1149,18 +1144,18 @@
 					this.qcConcCol.visible = false;
 					this.qcRINCol.visible = false;
 					this.qcStatusCol.visible = false;
-					
+
 				} else if (currentState == 'ExternalMicroarrayState') {
 					sampleTypeCol.visible = true;
 					organismCol.visible = false;
 					sampleVolumeCol.visible = false;
-					
+
 					this.otherOrganismCol.visible = false;
 					this.otherSamplePrepMethodCol.visible = false;
-					concentrationCol.visible = false; 
+					concentrationCol.visible = false;
 					preppedByLabCol.visible = false;
 					chipTypeCol.visible = false;
-					concentrationUnitCol.visible = false;        		
+					concentrationUnitCol.visible = false;
 					barcodeCol.visible = false;
 					plateNameCol.visible = false;
 					wellNameCol.visible = false;
@@ -1170,11 +1165,11 @@
 					this.qcConcCol.visible = false;
 					this.qcRINCol.visible = false;
 					this.qcStatusCol.visible = false;
-					
+
 				} else {
-					
-					descriptionCol.visible = true;   
-					
+
+					descriptionCol.visible = true;
+
 					if (currentState == 'SolexaState') {
 						concentrationCol.visible = true;
 						sampleVolumeCol.visible = true;
@@ -1193,10 +1188,10 @@
 						this.qcRINCol.visible = true;
 						this.qcStatusCol.visible = true;
 						descriptionCol.visible = false;
-						
+
 					} else if (currentState == 'QCState' || currentState == 'ExternalQCState') {
 						sampleVolumeCol.visible = false;
-						concentrationCol.visible = false; 
+						concentrationCol.visible = false;
 						sampleTypeCol.visible = false;
 						organismCol.visible = false;
 						preppedByLabCol.visible = false;
@@ -1214,7 +1209,7 @@
 						this.qcStatusCol.visible = currentState == 'QCState';
 					} else if (isCapSeqState()) {
 						sampleVolumeCol.visible = false;
-						concentrationCol.visible = false; 
+						concentrationCol.visible = false;
 						sampleTypeCol.visible = true;
 						organismCol.visible = false;
 						preppedByLabCol.visible = false;
@@ -1232,10 +1227,10 @@
 						reactionPlateCol.visible = true;
 						redoFlagCol.visible = true;
 						this.descriptionCol.visible = false;
-						
+
 					} else if (isMitSeqState()) {
 						sampleVolumeCol.visible = false;
-						concentrationCol.visible = false; 
+						concentrationCol.visible = false;
 						sampleTypeCol.visible = false;
 						organismCol.visible = false;
 						preppedByLabCol.visible = false;
@@ -1252,10 +1247,10 @@
 						this.qcStatusCol.visible = false;
 						reactionPlateCol.visible = true;
 						redoFlagCol.visible = true;
-						
+
 					} else if (isFragAnalState()) {
 						sampleVolumeCol.visible = false;
-						concentrationCol.visible = false; 
+						concentrationCol.visible = false;
 						sampleTypeCol.visible = false;
 						organismCol.visible = false;
 						preppedByLabCol.visible = false;
@@ -1273,7 +1268,7 @@
 						reactionPlateCol.visible = true;
 					} else if (isCherryPickState()) {
 						sampleVolumeCol.visible = false;
-						concentrationCol.visible = false; 
+						concentrationCol.visible = false;
 						sampleTypeCol.visible = false;
 						organismCol.visible = false;
 						preppedByLabCol.visible = false;
@@ -1292,10 +1287,10 @@
 						this.cherrySourcePlateCol.visible = true;
 						this.cherrySourceWellCol.visible = true;
 						reactionPlateCol.visible = true;
-						
+
 					} else if (isIScanState()) {
 						sampleVolumeCol.visible = false;
-						concentrationCol.visible = false; 
+						concentrationCol.visible = false;
 						sampleTypeCol.visible = false;
 						organismCol.visible = false;
 						preppedByLabCol.visible = false;
@@ -1315,10 +1310,10 @@
 						this.cherrySourceWellCol.visible = false;
 						reactionPlateCol.visible = false;
 						this.descriptionCol.visible = false;
-						
+
 					} else if (isSequenomState()) {
 						sampleVolumeCol.visible = false;
-						concentrationCol.visible = true; 
+						concentrationCol.visible = true;
 						sampleTypeCol.visible = true;
 						organismCol.visible = false;
 						preppedByLabCol.visible = false;
@@ -1334,10 +1329,10 @@
 						this.qcRINCol.visible = false;
 						this.qcStatusCol.visible = false;
 						this.descriptionCol.visible = false;
-						
+
 					} else if (isClinicalSequenomState()) {
 						sampleVolumeCol.visible = false;
-						concentrationCol.visible = true; 
+						concentrationCol.visible = true;
 						sampleTypeCol.visible = true;
 						organismCol.visible = false;
 						preppedByLabCol.visible = false;
@@ -1354,10 +1349,10 @@
 						this.qcStatusCol.visible = false;
 						this.descriptionCol.visible = false;
 						this.sampleNameColumn.visible = false;
-						
+
 					} else if (isIsolationState()) {
 						sampleVolumeCol.visible = false;
-						concentrationCol.visible = true; 
+						concentrationCol.visible = true;
 						sampleTypeCol.visible = false;
 						organismCol.visible = false;
 						preppedByLabCol.visible = false;
@@ -1374,11 +1369,11 @@
 						this.qcStatusCol.visible = false;
 						this.descriptionCol.visible = false;
 						this.sampleSourceCol.visible = true;
-						
+
 						//this.concentrationCol.headerText = 'NanoDrop Conc.';
 					} else if (isIonTorrentState()) {
 						sampleVolumeCol.visible = false;
-						concentrationCol.visible = true; 
+						concentrationCol.visible = true;
 						sampleTypeCol.visible = true;
 						organismCol.visible = true;
 						preppedByLabCol.visible = false;
@@ -1396,12 +1391,12 @@
 						this.descriptionCol.visible = false;
 						this.sampleSourceCol.visible = false;
 						applicationCol.visible = true;
-						
+
 						//this.concentrationCol.headerText = 'Conc. (ng/ul)';
-						
+
 					}  else if (isGenericState()) {
 						sampleVolumeCol.visible = false;
-						concentrationCol.visible = false; 
+						concentrationCol.visible = false;
 						sampleTypeCol.visible = true;
 						organismCol.visible = true;
 						preppedByLabCol.visible = false;
@@ -1420,19 +1415,19 @@
 						this.sampleSourceCol.visible = false;
 						applicationCol.visible = true;
 						if ( this.selectedExperiment.@codeRequestCategory == 'DDPCR' ){
-							concentrationCol.visible = true; 
+							concentrationCol.visible = true;
 							otherSamplePrepMethodCol.visible = true;
 							applicationCol.visible = false;
 						}
 					}  else {
 						sampleVolumeCol.visible = false;
-						concentrationCol.visible = true; 
+						concentrationCol.visible = true;
 						sampleTypeCol.visible = true;
 						organismCol.visible = true;
 						preppedByLabCol.visible = false;
 						otherSamplePrepMethodCol.visible = true;
 						chipTypeCol.visible = false;
-						concentrationUnitCol.visible = false;        		
+						concentrationUnitCol.visible = false;
 						plateNameCol.visible = false;
 						wellNameCol.visible = false;
 						isControlCol.visible = false;
@@ -1443,15 +1438,15 @@
 						this.qcStatusCol.visible = true;
 					}
 				}
-				
+
 				this.initializeBarcoding();
 				otherOrganismCol.visible = false;
 			}
-			
+
 			public function showRelatedAnalysis():void {
 				parentApplication.showAnalysisForExperiment(this.selectedExperiment);
 			}
-			
+
 			private function onDoubleClickRelatedAnalysis():void {
 				var selectedItem:Object = this.relatedAnalysisTree.selectedItem;
 				showRelatedObject(selectedItem);
@@ -1460,7 +1455,7 @@
 				var selectedItem:Object = this.relatedTopicsTree.selectedItem;
 				showRelatedObject(selectedItem);
 			}
-			
+
 			private function showRelatedObject(selectedItem:Object):void {
 				if (selectedItem.name() == "Analysis") {
 					parentApplication.showAnalysisForNumber(selectedItem.@number);
@@ -1470,355 +1465,355 @@
 					parentApplication.showTopicForNumber(selectedItem.@idTopic);
 				} else if (selectedItem.name() == "Request" && selectedExperiment.@idRequest != selectedItem.@idRequest) {
 					parentApplication.showExperimentById(selectedItem.@idRequest);
-				}			
+				}
 			}
-			
+
 			// Get all options (include inactive)
 			public function getPropertyOptions(idProperty:String):XMLList {
 				return parentApplication.getPropertyOptions(idProperty, true);
 			}
-			
+
 			private function addAssayColumns():void {
 				var columns:Array = samplesGridConfirm.columns;
 				var newColumns:Array = new Array();
-				
+
 				// remove any existing assay columns
 				var colRemoved:Boolean = false;
 				for each(var remCol:AdvancedDataGridColumn in columns) {
 					if (remCol.dataField == null || remCol.dataField.substr(0, 9) != "@hasAssay") {
 						newColumns.push(remCol);
-					} else {
-						colRemoved = true;
-					}
-				}
-				if (colRemoved) {
-					samplesGridConfirm.columns = newColumns;
-					samplesGridConfirm.validateNow();
-				}
-				
-				if (isFragAnalState()) {
-					columns = samplesGridConfirm.columns;
-					newColumns = new Array();
-					for each(var addCol:AdvancedDataGridColumn in columns) {
-						if (addCol.dataField == "@description") {
-							for each (var assay:Object in assays) {
-								var newCol:AdvancedDataGridColumn = new AdvancedDataGridColumn();
-								newCol.dataField  = "@hasAssay" + assay.@name;
-								newCol.headerText = assay.@name;
-								newCol.visible    = true;
-								newCol.width	  = 40;
-								newColumns.push(newCol);
-							}
-						}
-						newColumns.push(addCol);
-					}
-					samplesGridConfirm.columns = newColumns;
-					samplesGridConfirm.validateNow();
-				}
-			}
-			
-			public function addNonStandardSampleColumns():void {
-				var annotation:Object;
-				var col:AdvancedDataGridColumn;
-				var exists:Boolean = false;
-				
-				addAssayColumns();
-				
-				// Make all annotation columns not visible
-				for each(col in samplesGridConfirm.columns) {
-					if (col.dataField != null && col.dataField.substr(0, 6) == "@ANNOT") {
-						col.visible    = false;       				
-					}    				
-				}
-				
-				if (!isMitSeqState() && !isCherryPickState()) {
-					for each(annotation in this.selectedExperiment.PropertyEntries.PropertyEntry) {
+                    } else {
+                        colRemoved = true;
+                    }
+                }
+                if (colRemoved) {
+                    samplesGridConfirm.columns = newColumns;
+                    samplesGridConfirm.validateNow();
+                }
 
-						if(annotation.@idProperty == "-1") {
-							continue;
-						}
-						
-						var property:XML = parentApplication.getSampleProperty(annotation.@idProperty);
-						if ( property == null ) {
-							continue;
-						}
-						var headerName:String = "";
-						if (property.@name == "Other" && annotation.@otherLabel != "" ) {
-							headerName = annotation.@otherLabel;
-							annotation.@isSelected = "true";
-						} else {
-							headerName = annotation.@name;
-						}
-						
-						// Note we don't specify application because that is taken care of in the back end (GetRequest).
-						var isApplicable:Boolean = AnnotationUtility.isApplicableProperty(parentApplication.getSampleProperty(annotation.@idProperty),
-							parentApplication.dictionaryManager.getEntry('hci.gnomex.model.RequestCategory',this.selectedExperiment.@codeRequestCategory),
-							this.selectedExperiment.@idOrganism, this.selectedExperiment.@codeApplication);
-						
-						exists = false;
-						
-						for each(col in samplesGridConfirm.columns) {
-							if (col.dataField == ("@ANNOT" + annotation.@idProperty)) {
-								exists = true;
-								col.visible    = annotation.@isSelected == "true" && isApplicable ? true : false;       				
-								col.headerText = headerName;
-								break;
-							}    				
-						}
-						
-						// We already have this column.  Just set the header and visible and move on.
-						var newCol:AdvancedDataGridToolTipColumn = new AdvancedDataGridToolTipColumn();
-						if (exists) {
-							newCol = AdvancedDataGridToolTipColumn(col);
-						} else {
-							newCol.dataField  = "@ANNOT" + annotation.@idProperty;
-							newCol.headerText = headerName;
-							newCol.visible    = (annotation.@isSelected == "true" && isApplicable ? true : false);
-							newCol.headerWordWrap = true;
-							if (property.@description != null && property.@description.toString() != "") {
-								newCol.headerToolTip = property.@description
-							} else {
-								newCol.headerToolTip = property.@name;
-							}
+                if (isFragAnalState()) {
+                    columns = samplesGridConfirm.columns;
+                    newColumns = new Array();
+                    for each(var addCol:AdvancedDataGridColumn in columns) {
+                        if (addCol.dataField == "@description") {
+                            for each (var assay:Object in assays) {
+                                var newCol:AdvancedDataGridColumn = new AdvancedDataGridColumn();
+                                newCol.dataField  = "@hasAssay" + assay.@name;
+                                newCol.headerText = assay.@name;
+                                newCol.visible    = true;
+                                newCol.width	  = 40;
+                                newColumns.push(newCol);
+                            }
+                        }
+                        newColumns.push(addCol);
+                    }
+                    samplesGridConfirm.columns = newColumns;
+                    samplesGridConfirm.validateNow();
+                }
+            }
 
-							if (property.@codePropertyType == 'MOPTION') {
-								newCol.itemRenderer =  MultiselectRenderer.create(false);
-							} else if (property.@codePropertyType == 'URL') {
-								newCol.itemRenderer = URLRenderer.create(false);
-							} else if (property.@codePropertyType == 'CHECK') {
-								// checkbox is just normal label renderer
-							} else if (property.@codePropertyType == 'OPTION') {             
-								newCol.itemRenderer = views.renderers.DropdownLabel.create(
-									parentApplication.getPropertyOptions(annotation.@idProperty), 
-									'@option', 
-									'@idPropertyOption', 
-									"@ANNOT" + annotation.@idProperty,
-									'',
-									false);                
-							} else{
-								newCol.wordWrap = true;
-							}
-						}						
-						
-						// Place the new column right after the description column
-						var columns:Array = samplesGridConfirm.columns;
-						var newColumns:Array = new Array();
-						for each(var column:AdvancedDataGridColumn in columns) {
-							if((currentState == 'SolexaState' || currentState == 'MicroarrayState' || currentState == 'QCState' 
-								|| currentState == null || isNanoStringState() || this.isSequenomState() || this.isIonTorrentState() || currentState == 'ExternalMicroarrayState'
-								|| currentState == 'ExternalSeqState' || currentState == 'ExternalQCState') && column.dataField == "@idSampleType"){
-									newColumns.push(newCol);
-							}
-							
-							if (column != newCol) {
-								newColumns.push(column);
-							}
-						}
-						
-						if(this.isIsolationState() || this.isIScanState() || this.isCapSeqState() || this.isFragAnalState() ){
-							newColumns.push(newCol);
-						}
-						
-						samplesGridConfirm.columns = newColumns;
-						
-						samplesGridConfirm.validateNow();
-					} 
-				}   		
-			}
-			
-			private function showProtocol(idProtocol:Object, protocolClassName:String):void {
-				var params:Object = new Object();
-				params.id = idProtocol;
-				params.protocolClassName = protocolClassName;
-				getProtocol.send(params);
-			}
-			
-			private function showAdapters(protocolClassName:String, fivePrime:String, threePrime:String):void {
-				var adapterWindow:AdapterWindow = AdapterWindow(PopUpManager.createPopUp(DisplayObject(this.parentDocument), AdapterWindow, false));
-				PopUpManager.centerPopUp(adapterWindow);
-				adapterWindow.title = protocolClassName;
-				adapterWindow.adapterTextArea.text = "Read 1 Adapter:\n " + threePrime + "\n\n" + "Read 2 Adapter:\n " + fivePrime;
-			}
-			
-			private function onGetProtocol(event:ResultEvent): void { 
-				if (getProtocol.lastResult.name() != "Protocol") {
-					mx.controls.Alert.show(getProtocol.lastResult..ACTMESSAGE.@TEXT);
-					return;
-				}
-				var protocolWindow:ProtocolWindow = ProtocolWindow(PopUpManager.createPopUp(DisplayObject(this.parentDocument), ProtocolWindow, false));
-				PopUpManager.centerPopUp(protocolWindow);
-				protocolWindow.init(getProtocol.lastResult);
-			}
-			
-			public function getLaneTreeIcon(item:Object):Class {
-				return null; 
-			} 
-			
-			public function refreshDownloadList():void {
+            public function addNonStandardSampleColumns():void {
+                var annotation:Object;
+                var col:AdvancedDataGridColumn;
+                var exists:Boolean = false;
 
-				if (theTab.selectedChild == filesView) {
-					var params:Object = new Object();
-					params.idRequest = this.selectedExperiment.@idRequest;
-					if (parentApplication.needToLoad(params) ) {				
-						var oldId:String = parentApplication.lastGetRequestDownloadListidRequest;
-						var newId:String = parentApplication.lastGetRequestDownloadListrequestNumber;
-						if (oldId == null) oldId = "crap";
-						if (newId == null) newId = "crap";
-						params.whereami = "1" + "/" + oldId + "/" + newId;
+                addAssayColumns();
 
-						filesView.getRequestDownloadList.send(params);
-					} 
+                // Make all annotation columns not visible
+                for each(col in samplesGridConfirm.columns) {
+                    if (col.dataField != null && col.dataField.substr(0, 6) == "@ANNOT") {
+                        col.visible    = false;
+                    }
+                }
 
-					filesView.browseParameters = params;
-				}
-			}
-			
-			public function filterList():void{		}
-			
-			protected function tabChangeHandler(event:IndexChangedEvent):void
-			{
-				refreshDownloadList();
-			}
-			
-			[Bindable]
-			private var selectedFileList:XMLListCollection;
-			
-			public function isControlLabelFunction(item:Object, column:AdvancedDataGridColumn):String
-			{
-				if (item is XML) {
-					if (item.@isControl == "N") {
-						return "";
-					} else {
-						return item.@isControl;
-					}
-				} else {
-					return "";
-				}
-			}
-			
-			public function groupNameLabelFunction(item:Object, column:AdvancedDataGridColumn):String
-			{
-				if (item is XML) {
-					return "";
-				} else {
-					return item.groupLabel;
-				}
-			}
-			
-			public function navigateToURLLink(ccNumber:String):void {
-				
-				if ( ccNumber == null ) {
-					return;
-				}
-				
-				var url:String = parentApplication.getProperty(parentApplication.PROPERTY_GNOMEX_LINKAGE_BST_URL) + "#ccNumber=" + ccNumber;
-				
-				navigateToURL( new URLRequest(url), '_blank' );
-			}
-			
-			private function showCollaboratorWindow():void {
-				var collaboratorWindow:CollaboratorWindow = CollaboratorWindow(PopUpManager.createPopUp(parentApplication.theBody, CollaboratorWindow, true));
-				PopUpManager.centerPopUp(collaboratorWindow);
-				collaboratorWindow.init("Collaborators for Experiment " + selectedExperiment.@number, 
-					collaborators, 
-					selectedExperiment);
-				
-			}
-			
-			private function filterPropertyEntry(sce:Object):Boolean {
-				var keep:Boolean = false;
-				
-				var property:XML = parentApplication.getSampleProperty(sce.@idProperty);
-				if(sce.@idProperty == "-1" || property == null) {
-					return true;	// Special case for "Description" field which is not a "real" property 
-				}
-				var requestCategory:Object = parentApplication.dictionaryManager.getEntry('hci.gnomex.model.RequestCategory',this.selectedExperiment.@codeRequestCategory);
-				if (AnnotationUtility.isApplicableProperty(property, requestCategory, this.selectedExperiment.@idOrganism, selectedExperiment.@codeApplication)) {
-					if (sce.@isSelected == 'true' || property.@isActive != 'N') {
-						keep = true;
-					}
-				}
-				
-				return keep;
-			}
-			
-			private function downloadSampleSheet():void{
-				var fieldList:XMLListCollection = this.getFieldList();
-				var showUrl:URLRequest = new URLRequest('DownloadSampleSheet.gx');
-				var uv:URLVariables = new URLVariables();
-				showUrl.contentType = "application/x-www-form-urlencoded";
-				var names:String = "<NameList>"
-				for each (var node : XML in fieldList){
-					names += node.toXMLString();
-				}
-								
-				names += "</NameList>";
-				uv.names = names;
-				uv.requestXMLString = this.selectedExperiment.toXMLString();
-				showUrl.data = uv;
-				showUrl.method = URLRequestMethod.POST;
-				navigateToURL(showUrl, '_blank');
-			}
-			
-			private function getFieldList():XMLListCollection {
-				
-				var fieldList:XMLListCollection = new XMLListCollection();
-				// Build the contents of the columns selection list
-				var grid:CopyPasteSampleGrid = samplesGridConfirm;
-				for each(var col:AdvancedDataGridColumn in grid.columns) {
-					if(col.visible == false || col.headerText == ""){
-						continue;
-					}
-					if (col.dataField != null && col.dataField == '@codeConcentrationUnit') {
-						continue;
-					}
+                if (!isMitSeqState() && !isCherryPickState()) {
+                    for each(annotation in this.selectedExperiment.PropertyEntries.PropertyEntry) {
 
-					var fieldType:String = "TEXT";
-					if(col is AdvancedDataGridColumnWithType) {
-						fieldType = AdvancedDataGridColumnWithType(col).propertyType;
-					}
-					
-						var emptyNode:XML = new XML("<FieldItem " +
-							" dataField='" + col.dataField + "' fieldText='" + col.headerText +
-							"' fieldType='" + fieldType + "' selectedSSColumn='0'/>");
-						fieldList.addItem(emptyNode);
-				}					
-				
-				return fieldList;
-			}
-			
-			private function getSampleConcentrationFormatted(item:Object, column:AdvancedDataGridColumn):String {
-				numberFormatter.precision = sampleConcentrationPrecision;
-				if (item.hasOwnProperty("@concentration") && item.@concentration != '') {
-					return numberFormatter.format(item.@concentration);
-				} else {
-					return "";
-				}
-			}
+                        if(annotation.@idProperty == "-1") {
+                            continue;
+                        }
 
-			private function getSampleVolumeFormatted(item:Object, column:AdvancedDataGridColumn):String {
-				numberFormatter.precision = sampleConcentrationPrecision;
-				if (item.hasOwnProperty("@sampleVolume") && item.@sampleVolume != '') {
-					return numberFormatter.format(item.@sampleVolume);
-				} else {
-					return "";
-				}
-			}
-			
-			private function determineToShowProductsTab(requestCategory:Object):Boolean {
-				if (selectedExperiment != null && selectedExperiment.@isExternal != 'Y' && requestCategory != null) {
-					if (requestCategory.@idProductType != null && requestCategory.@idProductType != '') {
-						return true;
-					}
-				}
-				
-				return false;
-			}
-			
-			private function getConcentrationHeader():void{
-				if(this.samples.length > 0){
-					concHeader += "("+samples.getItemAt(0).@codeConcentrationUnit+")";
-				}
+                        var property:XML = parentApplication.getSampleProperty(annotation.@idProperty);
+                        if ( property == null ) {
+                            continue;
+                        }
+                        var headerName:String = "";
+                        if (property.@name == "Other" && annotation.@otherLabel != "" ) {
+                            headerName = annotation.@otherLabel;
+                            annotation.@isSelected = "true";
+                        } else {
+                            headerName = annotation.@name;
+                        }
+
+                        // Note we don't specify application because that is taken care of in the back end (GetRequest).
+                        var isApplicable:Boolean = AnnotationUtility.isApplicableProperty(parentApplication.getSampleProperty(annotation.@idProperty),
+                                parentApplication.dictionaryManager.getEntry('hci.gnomex.model.RequestCategory',this.selectedExperiment.@codeRequestCategory),
+                                this.selectedExperiment.@idOrganism, this.selectedExperiment.@codeApplication);
+
+                        exists = false;
+
+                        for each(col in samplesGridConfirm.columns) {
+                            if (col.dataField == ("@ANNOT" + annotation.@idProperty)) {
+                                exists = true;
+                                col.visible    = annotation.@isSelected == "true" && isApplicable ? true : false;
+                                col.headerText = headerName;
+                                break;
+                            }
+                        }
+
+                        // We already have this column.  Just set the header and visible and move on.
+                        var newCol:AdvancedDataGridToolTipColumn = new AdvancedDataGridToolTipColumn();
+                        if (exists) {
+                            newCol = AdvancedDataGridToolTipColumn(col);
+                        } else {
+                            newCol.dataField  = "@ANNOT" + annotation.@idProperty;
+                            newCol.headerText = headerName;
+                            newCol.visible    = (annotation.@isSelected == "true" && isApplicable ? true : false);
+                            newCol.headerWordWrap = true;
+                            if (property.@description != null && property.@description.toString() != "") {
+                                newCol.headerToolTip = property.@description
+                            } else {
+                                newCol.headerToolTip = property.@name;
+                            }
+
+                            if (property.@codePropertyType == 'MOPTION') {
+                                newCol.itemRenderer =  MultiselectRenderer.create(false);
+                            } else if (property.@codePropertyType == 'URL') {
+                                newCol.itemRenderer = URLRenderer.create(false);
+                            } else if (property.@codePropertyType == 'CHECK') {
+                                // checkbox is just normal label renderer
+                            } else if (property.@codePropertyType == 'OPTION') {
+                                newCol.itemRenderer = views.renderers.DropdownLabel.create(
+                                        parentApplication.getPropertyOptions(annotation.@idProperty),
+                                        '@option',
+                                        '@idPropertyOption',
+                                        "@ANNOT" + annotation.@idProperty,
+                                        '',
+                                        false);
+                            } else{
+                                newCol.wordWrap = true;
+                            }
+                        }
+
+                        // Place the new column right after the description column
+                        var columns:Array = samplesGridConfirm.columns;
+                        var newColumns:Array = new Array();
+                        for each(var column:AdvancedDataGridColumn in columns) {
+                            if((currentState == 'SolexaState' || currentState == 'MicroarrayState' || currentState == 'QCState'
+                                    || currentState == null || isNanoStringState() || this.isSequenomState() || this.isIonTorrentState() || currentState == 'ExternalMicroarrayState'
+                                    || currentState == 'ExternalSeqState' || currentState == 'ExternalQCState') && column.dataField == "@idSampleType"){
+                                newColumns.push(newCol);
+                            }
+
+                            if (column != newCol) {
+                                newColumns.push(column);
+                            }
+                        }
+
+                        if(this.isIsolationState() || this.isIScanState() || this.isCapSeqState() || this.isFragAnalState() ){
+                            newColumns.push(newCol);
+                        }
+
+                        samplesGridConfirm.columns = newColumns;
+
+                        samplesGridConfirm.validateNow();
+                    }
+                }
+            }
+
+            private function showProtocol(idProtocol:Object, protocolClassName:String):void {
+                var params:Object = new Object();
+                params.id = idProtocol;
+                params.protocolClassName = protocolClassName;
+                getProtocol.send(params);
+            }
+
+            private function showAdapters(protocolClassName:String, fivePrime:String, threePrime:String):void {
+                var adapterWindow:AdapterWindow = AdapterWindow(PopUpManager.createPopUp(DisplayObject(this.parentDocument), AdapterWindow, false));
+                PopUpManager.centerPopUp(adapterWindow);
+                adapterWindow.title = protocolClassName;
+                adapterWindow.adapterTextArea.text = "Read 1 Adapter:\n " + threePrime + "\n\n" + "Read 2 Adapter:\n " + fivePrime;
+            }
+
+            private function onGetProtocol(event:ResultEvent): void {
+                if (getProtocol.lastResult.name() != "Protocol") {
+                    mx.controls.Alert.show(getProtocol.lastResult..ACTMESSAGE.@TEXT);
+                    return;
+                }
+                var protocolWindow:ProtocolWindow = ProtocolWindow(PopUpManager.createPopUp(DisplayObject(this.parentDocument), ProtocolWindow, false));
+                PopUpManager.centerPopUp(protocolWindow);
+                protocolWindow.init(getProtocol.lastResult);
+            }
+
+            public function getLaneTreeIcon(item:Object):Class {
+                return null;
+            }
+
+            public function refreshDownloadList():void {
+
+                if (theTab.selectedChild == filesView) {
+                    var params:Object = new Object();
+                    params.idRequest = this.selectedExperiment.@idRequest;
+                    if (parentApplication.needToLoad(params) ) {
+                        var oldId:String = parentApplication.lastGetRequestDownloadListidRequest;
+                        var newId:String = parentApplication.lastGetRequestDownloadListrequestNumber;
+                        if (oldId == null) oldId = "crap";
+                        if (newId == null) newId = "crap";
+                        params.whereami = "1" + "/" + oldId + "/" + newId;
+
+                        filesView.getRequestDownloadList.send(params);
+                    }
+
+                    filesView.browseParameters = params;
+                }
+            }
+
+            public function filterList():void{		}
+
+            protected function tabChangeHandler(event:IndexChangedEvent):void
+            {
+                refreshDownloadList();
+            }
+
+            [Bindable]
+            private var selectedFileList:XMLListCollection;
+
+            public function isControlLabelFunction(item:Object, column:AdvancedDataGridColumn):String
+            {
+                if (item is XML) {
+                    if (item.@isControl == "N") {
+                        return "";
+                    } else {
+                        return item.@isControl;
+                    }
+                } else {
+                    return "";
+                }
+            }
+
+            public function groupNameLabelFunction(item:Object, column:AdvancedDataGridColumn):String
+            {
+                if (item is XML) {
+                    return "";
+                } else {
+                    return item.groupLabel;
+                }
+            }
+
+            public function navigateToURLLink(ccNumber:String):void {
+
+                if ( ccNumber == null ) {
+                    return;
+                }
+
+                var url:String = parentApplication.getProperty(parentApplication.PROPERTY_GNOMEX_LINKAGE_BST_URL) + "#ccNumber=" + ccNumber;
+
+                navigateToURL( new URLRequest(url), '_blank' );
+            }
+
+            private function showCollaboratorWindow():void {
+                var collaboratorWindow:CollaboratorWindow = CollaboratorWindow(PopUpManager.createPopUp(parentApplication.theBody, CollaboratorWindow, true));
+                PopUpManager.centerPopUp(collaboratorWindow);
+                collaboratorWindow.init("Collaborators for Experiment " + selectedExperiment.@number,
+                        collaborators,
+                        selectedExperiment);
+
+            }
+
+            private function filterPropertyEntry(sce:Object):Boolean {
+                var keep:Boolean = false;
+
+                var property:XML = parentApplication.getSampleProperty(sce.@idProperty);
+                if(sce.@idProperty == "-1" || property == null) {
+                    return true;	// Special case for "Description" field which is not a "real" property
+                }
+                var requestCategory:Object = parentApplication.dictionaryManager.getEntry('hci.gnomex.model.RequestCategory',this.selectedExperiment.@codeRequestCategory);
+                if (AnnotationUtility.isApplicableProperty(property, requestCategory, this.selectedExperiment.@idOrganism, selectedExperiment.@codeApplication)) {
+                    if (sce.@isSelected == 'true' || property.@isActive != 'N') {
+                        keep = true;
+                    }
+                }
+
+                return keep;
+            }
+
+            private function downloadSampleSheet():void{
+                var fieldList:XMLListCollection = this.getFieldList();
+                var showUrl:URLRequest = new URLRequest('DownloadSampleSheet.gx');
+                var uv:URLVariables = new URLVariables();
+                showUrl.contentType = "application/x-www-form-urlencoded";
+                var names:String = "<NameList>"
+                for each (var node : XML in fieldList){
+                    names += node.toXMLString();
+                }
+
+                names += "</NameList>";
+                uv.names = names;
+                uv.requestXMLString = this.selectedExperiment.toXMLString();
+                showUrl.data = uv;
+                showUrl.method = URLRequestMethod.POST;
+                navigateToURL(showUrl, '_blank');
+            }
+
+            private function getFieldList():XMLListCollection {
+
+                var fieldList:XMLListCollection = new XMLListCollection();
+                // Build the contents of the columns selection list
+                var grid:CopyPasteSampleGrid = samplesGridConfirm;
+                for each(var col:AdvancedDataGridColumn in grid.columns) {
+                    if(col.visible == false || col.headerText == ""){
+                        continue;
+                    }
+                    if (col.dataField != null && col.dataField == '@codeConcentrationUnit') {
+                        continue;
+                    }
+
+                    var fieldType:String = "TEXT";
+                    if(col is AdvancedDataGridColumnWithType) {
+                        fieldType = AdvancedDataGridColumnWithType(col).propertyType;
+                    }
+
+                    var emptyNode:XML = new XML("<FieldItem " +
+                            " dataField='" + col.dataField + "' fieldText='" + col.headerText +
+                            "' fieldType='" + fieldType + "' selectedSSColumn='0'/>");
+                    fieldList.addItem(emptyNode);
+                }
+
+                return fieldList;
+            }
+
+            private function getSampleConcentrationFormatted(item:Object, column:AdvancedDataGridColumn):String {
+                numberFormatter.precision = sampleConcentrationPrecision;
+                if (item.hasOwnProperty("@concentration") && item.@concentration != '') {
+                    return numberFormatter.format(item.@concentration);
+                } else {
+                    return "";
+                }
+            }
+
+            private function getSampleVolumeFormatted(item:Object, column:AdvancedDataGridColumn):String {
+                numberFormatter.precision = sampleConcentrationPrecision;
+                if (item.hasOwnProperty("@sampleVolume") && item.@sampleVolume != '') {
+                    return numberFormatter.format(item.@sampleVolume);
+                } else {
+                    return "";
+                }
+            }
+
+            private function determineToShowProductsTab(requestCategory:Object):Boolean {
+                if (selectedExperiment != null && selectedExperiment.@isExternal != 'Y' && requestCategory != null) {
+                    if (requestCategory.@idProductType != null && requestCategory.@idProductType != '') {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            private function getConcentrationHeader():void{
+                if(this.samples.length > 0){
+                    concHeader += "("+samples.getItemAt(0).@codeConcentrationUnit+")";
+                }
 			}
 			
 		]]>

--- a/flex/views/experiment/TabSamplesIllumina.mxml
+++ b/flex/views/experiment/TabSamplesIllumina.mxml
@@ -1338,7 +1338,43 @@
 										   width="140" dataField="@otherOrganism"
 										   visible="false"
 										   itemEditor="{views.renderers.GridColumnFillButton.create(new mx.controls.TextInput(), '')}" 
-										   editorDataField="value"/> 
+										   editorDataField="value"/>
+
+				<mx:AdvancedDataGridColumn visible="{!isExternal &amp;&amp; isEditState}"
+										   editable="{parentApplication.hasPermission('canWriteAnyObject')}"
+										   headerText="QC Conc. ng/uL"
+										   width="80"
+										   dataField="@qualCalcConcentration"
+										   id="qualCalcConcCol"
+										   itemEditor="{views.renderers.GridColumnFillButton.create(new mx.controls.TextInput(), '')}"
+										   editorDataField="value">
+					<mx:headerRenderer >
+						<mx:Component>
+							<mx:VBox verticalGap="0"   horizontalScrollPolicy="off" verticalScrollPolicy="off" horizontalAlign="center" verticalAlign="middle">
+								<util:ContextHelp context1="sampleQCConc" context2="{outerDocument.parentDocument.coreFacility.@idCoreFacility}" title="QC Conc. Help" showEdit="{parentApplication.isAdminState}"
+												  label="QC Conc.&#13;(ng/uL)" noIconSpaceIfNoHelp="true"/>
+							</mx:VBox>
+						</mx:Component>
+					</mx:headerRenderer>
+				</mx:AdvancedDataGridColumn>
+
+				<mx:AdvancedDataGridColumn visible="{!isExternal &amp;&amp; isEditState}"
+										   editable="{parentApplication.hasPermission('canWriteAnyObject')}"
+										   headerText="QC RIN"
+										   width="70"
+										   dataField="@qualRINNumber"
+										   id="qualRINCol"
+										   itemEditor="{views.renderers.GridColumnFillButton.create(new mx.controls.TextInput(), '')}"
+										   editorDataField="value">
+					<mx:headerRenderer >
+						<mx:Component>
+							<mx:VBox verticalGap="0"   horizontalScrollPolicy="off" verticalScrollPolicy="off" horizontalAlign="center" verticalAlign="middle">
+								<util:ContextHelp context1="sampleQualRINCol" context2="{outerDocument.parentDocument.coreFacility.@idCoreFacility}" title="QC RIN Help" showEdit="{parentApplication.isAdminState}"
+												  label="QC RIN" noIconSpaceIfNoHelp="true"/>
+							</mx:VBox>
+						</mx:Component>
+					</mx:headerRenderer>
+				</mx:AdvancedDataGridColumn>
 
 				<util:AdvancedDataGridColumnWithType id="seqLibProtocolCol" propertyType="OPTION" headerText="Seq Lib Protocol" visible="{true}"  width="180" dataField="@idSeqLibProtocol" 
 										   		   	 editorDataField="value" sortable="false" editable="{isEditState}" rendererIsEditor="false"
@@ -1455,23 +1491,6 @@
 				</mx:AdvancedDataGridColumn>
 				
 				
-				<mx:AdvancedDataGridColumn visible="{!isExternal &amp;&amp; isEditState}" 
-										   editable="{parentApplication.hasPermission('canWriteAnyObject')}" 
-										   headerText="QC Conc. ng/uL" 
-										   width="80" 
-										   dataField="@qualCalcConcentration" 
-										   id="qualCalcConcCol" 
-										   itemEditor="{views.renderers.GridColumnFillButton.create(new mx.controls.TextInput(), '')}" 
-										   editorDataField="value">
-					<mx:headerRenderer > 
-						<mx:Component>
-							<mx:VBox verticalGap="0"   horizontalScrollPolicy="off" verticalScrollPolicy="off" horizontalAlign="center" verticalAlign="middle"> 
-								<util:ContextHelp context1="sampleQCConc" context2="{outerDocument.parentDocument.coreFacility.@idCoreFacility}" title="QC Conc. Help" showEdit="{parentApplication.isAdminState}"
-												  label="QC Conc.&#13;(ng/uL)" noIconSpaceIfNoHelp="true"/>
-							</mx:VBox> 
-						</mx:Component>
-					</mx:headerRenderer>
-				</mx:AdvancedDataGridColumn>
 				<mx:AdvancedDataGridColumn id="meanLibSizeActual" visible="false" headerText="Actual Ave Lib Size" width="90" dataField="@meanLibSizeActual" editable="true">
 					<mx:headerRenderer > 
 						<mx:Component>
@@ -1499,24 +1518,7 @@
 						</mx:Component>
 					</mx:headerRenderer>
 				</mx:AdvancedDataGridColumn>
-				<mx:AdvancedDataGridColumn visible="{!isExternal &amp;&amp; isEditState}" 
-										   editable="{parentApplication.hasPermission('canWriteAnyObject')}" 
-										   headerText="QC RIN" 
-										   width="70" 
-										   dataField="@qualRINNumber" 
-										   id="qualRINCol" 
-										   itemEditor="{views.renderers.GridColumnFillButton.create(new mx.controls.TextInput(), '')}" 
-										   editorDataField="value">
-					<mx:headerRenderer > 
-						<mx:Component>
-							<mx:VBox verticalGap="0"   horizontalScrollPolicy="off" verticalScrollPolicy="off" horizontalAlign="center" verticalAlign="middle"> 
-								<util:ContextHelp context1="sampleQualRINCol" context2="{outerDocument.parentDocument.coreFacility.@idCoreFacility}" title="QC RIN Help" showEdit="{parentApplication.isAdminState}"
-												  label="QC RIN" noIconSpaceIfNoHelp="true"/>
-							</mx:VBox> 
-						</mx:Component>
-					</mx:headerRenderer>
-				</mx:AdvancedDataGridColumn>
-				<mx:AdvancedDataGridColumn visible="{!isExternal &amp;&amp; isEditState}" 
+				<mx:AdvancedDataGridColumn visible="{!isExternal &amp;&amp; isEditState}"
 										   editable="{parentApplication.hasPermission('canWriteAnyObject')}" 
 										   headerText="QC Frag size (from)" 
 										   width="87" 


### PR DESCRIPTION
We will not merge this pull request with master until we've completed the release and are officially on the next one. There are two changes in this pull request. Here are the diffs:

[changes for GNOM-2136](https://github.com/hci-gnomex/gnomex/compare/ebff85a96ebf177601353c9f1203633e0f518f13...cc4f0eee9b718da1a095502a4574bfc2a3e27753?w=0)
- ExperimentDetailView.mxml : The changes here are to add a new placeSpecialQualColumns() function that moves the "QC Conc" and "QC RIN" fields based on the core facility.
 - The "QC Conc" and "QC RIN" fields should display before the "Seq Lib Protocol" for experiments in core "High Throughput Genomics". Other cores should see the original ordering.
- TabSamplesIllumina.mxml : The changes here are just cutting and pasting to move fields
 - This moves the fields for Illumina-type experiments in all cores, not just for High Throughput Genomics
- Waiting for feedback: There is an inconsistency for now for Illumina-type experiments in other cores. Tarik will communicate with the other core(s) to see what they want, and I will adjust one of the two files as a result.

[code cleanup diff](https://github.com/hci-gnomex/gnomex/pull/39/commits/9cc73959437677a3afbf8d8cf7a1fa3ddd4e54b7?w=0)
- adjusted imports
- added missing semicolons
- simplified true/false assignments
- simplified assignments to empty objects and arrays
- remove unused variables and functions
- changed new object declaration to cast
- changed variable name to make it unique
- removed commented line
- initialized loop variable
