### PR TITLE
WIP: GNOM-1125

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,12 @@
+#IntelliJ
 .idea/
 *.iml
+
+#gradle
+.gradle/
+
+#project
+build/
 dist/
+out/
 glsave/

--- a/build.properties
+++ b/build.properties
@@ -63,7 +63,7 @@ opensource.orion.name=gnomex_orion_${gnomex_version}
 opensource.tomcat.name=gnomex_tomcat_${gnomex_version}
 sandbox.dir=${basedir}/dist/sandbox
 
-build.dir=${basedir}/dist/build
+build.dir=${basedir}/build
 build.class.dir=${build.dir}/classes
 build.hibernate.dir=${build.dir}/hibernate
 

--- a/flex/views/experiment/ExperimentUploadWindow.mxml
+++ b/flex/views/experiment/ExperimentUploadWindow.mxml
@@ -145,7 +145,7 @@
 
         public function init(request:Object):void {
             this.idRequest = request.@idRequest;
-            this.requestNumber = request.@requestNumber;
+            this.requestNumber = request.@number;
             this.request = request;
 
             //remove linkSamplesTab if property not enabled or if the experiment isn't hiseq or miseq

--- a/flex/views/experiment/RenameExperimentWindow.mxml
+++ b/flex/views/experiment/RenameExperimentWindow.mxml
@@ -92,6 +92,7 @@
 			private function onOrganizeExperimentUploadFiles(event:ResultEvent):void{
 				if (organizeExperimentUploadFiles.lastResult.name() != "SUCCESS") {
 					mx.controls.Alert.show(organizeExperimentUploadFiles.lastResult..ACTMESSAGE.@TEXT);
+					dispatchEvent(new Event("refreshUploadFiles", true));
 				}
 				else{
 					dispatchEvent(new Event("refreshUploadFiles", true));


### PR DESCRIPTION
-  Added to gitignore for convenience
-  Changed the build.dir property in the ant build.properties file. My compileFlex gradle target was misbehaving without it.
-  Noticed a title element was not being displayed. Turns out it was referring to a non-existent attribute.
-  Added a refresh command to flex side to follow an error being received from _OrganizeExperimentUploadFiles.java_ (the command used in the rename process)

Please see https://ri-jira.hci.utah.edu/browse/GNOM-1125 for more details.