### PR TITLE
WIP : GNOM-2230 Pressing enter quickly can result in loss of data

### DIFF
--- a/flex/views/renderers/GridColumnFillButton.as
+++ b/flex/views/renderers/GridColumnFillButton.as
@@ -85,6 +85,8 @@ public class GridColumnFillButton extends HBox implements IDropInListItemRendere
 			// Otherwise, the component has a tendency to become null suddenly and unexpectedly.
 			edtComponent.setFocus();
 		}
+
+        itemSelected();
 	}
 
 	override protected function focusInHandler(event:FocusEvent):void

--- a/flex/views/renderers/GridColumnFillButton.as
+++ b/flex/views/renderers/GridColumnFillButton.as
@@ -86,6 +86,10 @@ public class GridColumnFillButton extends HBox implements IDropInListItemRendere
 			edtComponent.setFocus();
 		}
 
+		// This call is needed to ensure that multiple focus change events don't confuse the component.
+		// See JIRA Ticket GNOM-2230 for details.
+		// Easiest to see by commenting out, navigating to component, selecting an element and holding enter down.
+		// Replaces most data with null.
         itemSelected();
 	}
 


### PR DESCRIPTION
Data copied in additional location, doesn't get skipped on held enter or tab key