### PR TITLE
Bugfix for Lucene searches

### DIFF
--- a/src/main/java/hci/gnomex/security/SecurityAdvisor.java
+++ b/src/main/java/hci/gnomex/security/SecurityAdvisor.java
@@ -3230,9 +3230,9 @@ private void appendLuceneCoreFacilitiesIManage(StringBuffer searchText) {
 	for (CoreFacility cf : (Set<CoreFacility>) this.getCoreFacilitiesIManage()) {
 		if (!firstTime) {
 			searchText.append(" ");
-			firstTime = false;
 		}
 		searchText.append(cf.getIdCoreFacility());
+		firstTime = false;
 	}
 
 }


### PR DESCRIPTION
There was an issue where admins (though not super admins) could not correctly use the Lucene search bar.